### PR TITLE
Add DuckDB dual-write for resolver exports and snapshots

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -27,7 +27,7 @@ flowchart LR
 - [`resolver/cli`](resolver/cli): Command-line interface that answers a single forecast resolution query by combining registries and exported datasets. [`resolver_cli.py`](resolver/cli/resolver_cli.py) encapsulates cutoff selection rules and handles deltas vs. stock series.
 - [`resolver/api`](resolver/api): FastAPI wrapper exposing `/health` and `/resolve` endpoints via [`app.py`](resolver/api/app.py). Designed to share the same loaders as the CLI.
 - [`resolver/tests`](resolver/tests): Pytest suites covering connectors, schema validation, precedence logic, deltas, and documentation generators such as [`test_generate_schemas_md.py`](resolver/tests/test_generate_schemas_md.py).
-- [`resolver/db`](resolver/db): DuckDB schema + helpers. [`duckdb_io.py`](resolver/db/duckdb_io.py) initialises the schema, exposes `get_db()`, and writes `facts_raw`, `facts_resolved`, `facts_deltas`, `snapshots`, and `manifests` tables.
+- [`resolver/db`](resolver/db): DuckDB schema + helpers. [`duckdb_io.py`](resolver/db/duckdb_io.py) initialises the schema, exposes `get_db()`, and writes `facts_resolved`, `facts_deltas`, `snapshots`, and `manifests` tables.
 - [`resolver/docs`](resolver/docs): Extended documentation (pipeline overview, policy, data dictionary, troubleshooting) that complements this codemap for deep dives.
 
 ## Entrypoints & Commands
@@ -66,7 +66,7 @@ Schema authority lives in [`resolver/tools/schema.yml`](resolver/tools/schema.ym
 - **Reference & Review:** `resolver/reference/` and `resolver/review/` keep lightweight CSVs and overrides that *are* tracked to preserve auditability.
 
 ## DB Integration Toggle
-Set `RESOLVER_DB_URL` to enable dual-writing exports and snapshots into DuckDB (default `duckdb:///resolver/db/resolver.duckdb`). When present, `export_facts.py` appends to `facts_raw`, `freeze_snapshot.py` writes `facts_resolved`, `facts_deltas`, `snapshots`, and `manifests`, and the CLI/API prefer the database (`--backend db` / `backend=db`). Leave the variable unset to remain file-backed only.
+Set `RESOLVER_DB_URL` to enable dual-writing exports and snapshots into DuckDB (default `duckdb:///resolver/db/resolver.duckdb`). When present, `export_facts.py` appends to `facts_resolved` (and `facts_deltas` when available), `freeze_snapshot.py` records resolved totals, deltas, manifests, and snapshot metadata transactionally, and the CLI/API prefer the database (`--backend db` / `backend=db`). Leave the variable unset to remain file-backed only.
 
 ## Runbooks
 ### First-time setup

--- a/README.md
+++ b/README.md
@@ -126,6 +126,19 @@ recommended 25 MB / 150 MB thresholds and to fail if the tracked repo contents
 grow beyond ~2 GB. Temporary scratch files (`resolver/tmp/`,
 `resolver/exports/*_working.*`, etc.) stay out of Git history via `.gitignore`.
 
+### Resolver DuckDB dual-write
+
+Set the `RESOLVER_DB_URL` environment variable to enable database-backed parity
+for resolver exports. When the variable is present (for example,
+`RESOLVER_DB_URL=duckdb:///resolver/db/resolver.duckdb`),
+`resolver/tools/export_facts.py` mirrors its CSV/Parquet outputs into the
+`facts_resolved` (and, when supplied, `facts_deltas`) tables inside DuckDB.
+`resolver/tools/freeze_snapshot.py` then wraps snapshot freezes in a single
+transaction, recording the resolved totals, monthly deltas, manifest metadata,
+and a corresponding `snapshots` row. Leave `RESOLVER_DB_URL` unset to continue
+operating in file-only mode; all tooling falls back automatically when the
+variable is absent.
+
 What Forecaster Does (Pipeline)
 
 Select question(s)

--- a/SCHEMAS.md
+++ b/SCHEMAS.md
@@ -13,6 +13,11 @@
 - [staging.unhcr_odp](#stagingunhcrodp)
 - [staging.worldpop](#stagingworldpop)
 
+> **DuckDB dual-write:** set `RESOLVER_DB_URL` (for example,
+> `duckdb:///resolver/db/resolver.duckdb`) to mirror resolver exports and
+> snapshots into the tables documented below. When unset, the tooling remains
+> file-backed only.
+
 ## db.facts_deltas
 
 Monthly "new" deltas derived from resolved totals.


### PR DESCRIPTION
## Summary
- normalize resolver exports before dual-writing to DuckDB `facts_resolved`/`facts_deltas` tables when `RESOLVER_DB_URL` is set
- wrap snapshot freezes in a single DuckDB transaction and record manifests/snapshots while closing connections cleanly
- extend DB parity tests and refresh documentation to describe the DuckDB toggle and contracts

## Testing
- pytest resolver/tests/test_db_parity.py resolver/tests/test_exports_contract.py

------
https://chatgpt.com/codex/tasks/task_e_68e3c7b92768832c852d33b8fe9bd980