### PR TITLE
fix: harden duckdb inserts and exporter parity

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:1
+FROM mcr.microsoft.com/devcontainers/python:3.11
+
+# Optional: system deps (kept minimal)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/*
+
+# Workdir is set by devcontainer.json; keep image lean

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,33 +1,24 @@
 {
-  "name": "Python 3",
-  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bullseye",
+  "name": "Resolver Dev",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
   "customizations": {
-    "codespaces": {
-      "openFiles": [
-        "README.md",
-        "Dashboard/streamlit_app.py"
-      ]
-    },
     "vscode": {
-      "settings": {},
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python"
+      },
       "extensions": [
         "ms-python.python",
         "ms-python.vscode-pylance"
       ]
     }
   },
-  "updateContentCommand": "[ -f packages.txt ] && sudo apt update && sudo apt upgrade -y && sudo xargs apt install -y <packages.txt; [ -f requirements.txt ] && pip3 install --user -r requirements.txt; pip3 install --user streamlit; echo '✅ Packages installed and Requirements met'",
-  "postAttachCommand": {
-    "server": "streamlit run Dashboard/streamlit_app.py --server.enableCORS false --server.enableXsrfProtection false"
+  "remoteEnv": {
+    "RESOLVER_API_BACKEND": "db",
+    "RESOLVER_DB_URL": "duckdb:///workspaces/resolver.dev.duckdb",
+    "PY_BIN": "/usr/local/bin/python",
+    "PIP_DISABLE_PIP_VERSION_CHECK": "1"
   },
-  "portsAttributes": {
-    "8501": {
-      "label": "Application",
-      "onAutoForward": "openPreview"
-    }
-  },
-  "forwardPorts": [
-    8501
-  ]
+  "postCreateCommand": "/bin/bash -lc './.devcontainer/postCreate.sh'"
 }

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo ">> postCreate: Detecting Python interpreter used by VS Code..."
+PY_BIN="${PY_BIN:-/usr/local/bin/python}"
+if ! command -v "$PY_BIN" >/dev/null 2>&1; then
+  PY_BIN="$(command -v python)"
+fi
+echo ">> Using PY_BIN=$PY_BIN"
+
+echo ">> Upgrading pip and installing DB deps (offline-first)..."
+"$PY_BIN" -m pip install --upgrade pip
+
+OFFLINE_FAIL=0
+if [ -f "tools/offline_wheels/constraints-db.txt" ]; then
+  echo ">> Attempting offline install from tools/offline_wheels ..."
+  if ! "$PY_BIN" -m pip install --no-index --find-links tools/offline_wheels -r tools/offline_wheels/constraints-db.txt; then
+    OFFLINE_FAIL=1
+  fi
+else
+  OFFLINE_FAIL=1
+fi
+
+if [ "$OFFLINE_FAIL" = "1" ]; then
+  echo ">> Offline install not available or failed; falling back to online extras..."
+  if ! "$PY_BIN" -m pip install -e ".[db]"; then
+    "$PY_BIN" -m pip install duckdb pytest
+  fi
+fi
+
+echo ">> Verifying duckdb importability with the same interpreter..."
+"$PY_BIN" - <<'PYCODE'
+import sys
+print("Interpreter:", sys.executable)
+import duckdb
+print("duckdb installed:", duckdb.__version__)
+PYCODE
+
+echo ">> postCreate complete."

--- a/.github/workflows/resolver-ci-fast.yml
+++ b/.github/workflows/resolver-ci-fast.yml
@@ -43,27 +43,13 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
 
-      - name: Install dependencies (Poetry if available, else pip)
-        shell: bash
+      - name: Install dependencies (pip extras)
         run: |
-          set -eux
-          if [[ -f "pyproject.toml" ]]; then
-            python -m pip install --upgrade pip
-            if grep -q "\[tool.poetry\]" pyproject.toml; then
-              pip install poetry
-              poetry config virtualenvs.create false
-              poetry install --no-interaction --no-ansi
-            else
-              pip install -e .
-            fi
-          elif [[ -f "requirements.txt" ]]; then
-            python -m pip install --upgrade pip
-            pip install -r requirements.txt
-            pip install -e .
-          else
-            python -m pip install --upgrade pip
-            pip install -e .
-          fi
+          python -m pip install --upgrade pip
+          pip install -r resolver/requirements.txt
+          pip install -r resolver/requirements-dev.txt
+          pip install -e ".[test]"
+          python -m pip install pytest
 
       - name: Run fast tests
         run: |

--- a/.github/workflows/resolver-ci-nightly.yml
+++ b/.github/workflows/resolver-ci-nightly.yml
@@ -167,3 +167,46 @@ jobs:
           name: nightly-summary
           path: nightly-summary
           retention-days: 7
+
+  tests-db:
+    name: tests (db backend)
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    env:
+      RESOLVER_API_BACKEND: db
+      RESOLVER_DB_URL: duckdb:///${{ github.workspace }}/.ci-resolver.duckdb
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-db-${{ hashFiles('pyproject.toml', 'resolver/requirements.txt', 'resolver/requirements-dev.txt', 'tools/offline_wheels/constraints-db.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-db-
+
+      - name: Install resolver dependencies (db backend)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r resolver/requirements.txt
+          pip install -r resolver/requirements-dev.txt
+          pip install -e ".[db,test]"
+          python -m pip install pytest
+
+      - name: Show environment
+        run: |
+          python -V
+          python -c "import duckdb,sys;print('duckdb',duckdb.__version__)"
+          echo "BACKEND=$RESOLVER_API_BACKEND"
+          echo "DB_URL=$RESOLVER_DB_URL"
+
+      - name: Run tests (db)
+        run: |
+          pytest -q

--- a/.github/workflows/resolver-ci.yml
+++ b/.github/workflows/resolver-ci.yml
@@ -79,3 +79,45 @@ jobs:
           else:
               print('No broken intra-repo Markdown links found.')
           PY
+
+  tests-db:
+    name: tests (db backend)
+    runs-on: ubuntu-latest
+    env:
+      RESOLVER_API_BACKEND: db
+      RESOLVER_DB_URL: duckdb:///${{ github.workspace }}/.ci-resolver.duckdb
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-db-${{ hashFiles('pyproject.toml', 'resolver/requirements.txt', 'resolver/requirements-dev.txt', 'tools/offline_wheels/constraints-db.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-db-
+
+      - name: Install resolver dependencies (db backend)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r resolver/requirements.txt
+          pip install -r resolver/requirements-dev.txt
+          pip install -e ".[db,test]"
+          python -m pip install pytest
+
+      - name: Show environment
+        run: |
+          python -V
+          python -c "import duckdb,sys;print('duckdb',duckdb.__version__)"
+          echo "BACKEND=$RESOLVER_API_BACKEND"
+          echo "DB_URL=$RESOLVER_DB_URL"
+
+      - name: Run tests (db)
+        run: |
+          pytest -q

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -43,9 +43,10 @@ flowchart LR
 | `python resolver/tools/write_repo_state.py --mode daily --id 2025-09-30` | Copy exports/review outputs into `resolver/state/daily/...` for archival. | `--retain-days` controls pruning; stages deletions via Git. |
 | `python resolver/tools/check_sizes.py` | Warn/fail when exports or snapshots exceed configured size limits. | Thresholds via `RESOLVER_LIMIT_PARQUET_MB`, `RESOLVER_LIMIT_CSV_MB`, `RESOLVER_LIMIT_REPO_MB`. |
 | `python resolver/tools/generate_schemas_md.py --in resolver/tools/schema.yml --out SCHEMAS.md --sort` | Regenerate schema reference documentation. | Requires `pyyaml`; fails if schema definitions are missing. |
-| `python resolver/cli/resolver_cli.py --country "Philippines" --hazard "Tropical Cyclone" --cutoff 2025-09-30 --backend db` | Query the latest resolved fact (defaults to monthly "new" series). | Uses DuckDB when `RESOLVER_DB_URL`/`--backend db` is set; otherwise falls back to snapshots/exports. Optional `--series stock` for totals. |
+| `python resolver/cli/resolver_cli.py --country "Philippines" --hazard "Tropical Cyclone" --cutoff 2025-09-30 --backend db` | Query the latest resolved fact (defaults to monthly "new" series). | Reads file exports by default; set `--backend db` or `RESOLVER_CLI_BACKEND=db` to use DuckDB. Optional `--series stock` for totals. |
 | `uvicorn resolver.api.app:app --reload` | Serve the Resolver API locally. | Same data dependencies as the CLI; respects `RESOLVER_DEBUG` for verbose logs. |
 | `pytest -q resolver/tests/test_ingestion_smoke_all_connectors.py` | Offline smoke test covering stubbed connectors and schema checks. | Install dependencies from `resolver/requirements*.txt`; other targeted tests live under `resolver/tests/`. |
+| `pytest -q resolver/tests/test_db_query_contract.py` | Validate DB vs. file parity for resolver queries. | Install the DB extra with `pip install -e ".[db]"` (or `poetry install -E db`), set `RESOLVER_DB_URL` (e.g., `duckdb:///resolver.duckdb`), and export `RESOLVER_API_BACKEND=db`. |
 
 ## Data Contracts & Schemas
 Schema authority lives in [`resolver/tools/schema.yml`](resolver/tools/schema.yml) and the generated [`SCHEMAS.md`](SCHEMAS.md). Canonical columns for facts, deltas, and staging datasets follow the Resolver data dictionary ([`resolver/docs/data_dictionary.md`](resolver/docs/data_dictionary.md)). PIN/PA exports must include `event_id`, location/hazard tuples, metric/unit pairs, timestamps (`as_of_date`, `publication_date`, `ingested_at`), and citation fields (`publisher`, `source_type`, `source_url`, `doc_title`, `definition_text`). Monthly deltas add lineage columns such as `series_semantics`, `value_new`, `rebase_flag`, and `delta_negative_clamped` to explain adjustments. Regenerate documentation whenever schemas change so downstream teams can rely on `SCHEMAS.md` as the single source of truth.
@@ -66,7 +67,7 @@ Schema authority lives in [`resolver/tools/schema.yml`](resolver/tools/schema.ym
 - **Reference & Review:** `resolver/reference/` and `resolver/review/` keep lightweight CSVs and overrides that *are* tracked to preserve auditability.
 
 ## DB Integration Toggle
-Set `RESOLVER_DB_URL` to enable dual-writing exports and snapshots into DuckDB (default `duckdb:///resolver/db/resolver.duckdb`). When present, `export_facts.py` appends to `facts_resolved` (and `facts_deltas` when available), `freeze_snapshot.py` records resolved totals, deltas, manifests, and snapshot metadata transactionally, and the CLI/API prefer the database (`--backend db` / `backend=db`). Leave the variable unset to remain file-backed only.
+Set `RESOLVER_DB_URL` to enable dual-writing exports and snapshots into DuckDB (default `duckdb:///resolver/db/resolver.duckdb`). When present, `export_facts.py` appends to `facts_resolved` (and `facts_deltas` when available) and `freeze_snapshot.py` records resolved totals, deltas, manifests, and snapshot metadata transactionally. The CLI/API remain file-backed by default; opt into DuckDB with `--backend db`, `RESOLVER_CLI_BACKEND=db`, or `RESOLVER_API_BACKEND=db` (use `auto` to prefer DB when available).
 
 ## Runbooks
 ### First-time setup
@@ -121,8 +122,9 @@ Set `RESOLVER_DB_URL` to enable dual-writing exports and snapshots into DuckDB (
 
 ## Testing & CI
 - Local smoke tests: `pytest -q resolver/tests/test_ingestion_smoke_all_connectors.py` (stubbed ingestion), `pytest -q resolver/tests/test_resolved_and_review.py` (export pipeline), and connector-specific suites under `resolver/tests/ingestion/`.
+- DB backend contract: either install via proxy (`python -m pip install duckdb pytest` with `HTTP[S]_PROXY` set) or, for offline setups, refresh the vendored wheels (`python scripts/download_db_wheels.py` on an internet-connected machine, commit the `tools/offline_wheels/*.whl` files) and run `scripts/install_db_extra_offline.(sh|ps1)` before exporting `RESOLVER_DB_URL='duckdb:///resolver.duckdb'` and `RESOLVER_API_BACKEND=db`. Then execute `pytest -q resolver/tests/test_db_query_contract.py` to confirm parity.
 - Schema/documentation guardrails: `pytest -q resolver/tests/test_generate_schemas_md.py` ensures the Markdown generator stays deterministic.
-- Continuous integration: `.github/workflows/resolver-ci.yml` installs resolver requirements, runs offline connector smoke tests, ReliefWeb PDF unit tests, and performs intra-repo Markdown link checking. Nightly workflows extend this with live runs and state archival.
+- Continuous integration: `.github/workflows/resolver-ci.yml` now includes a dedicated `tests (db backend)` job that installs the DuckDB extra and runs the full suite alongside the existing file-mode smoke tests. Nightly workflows mirror this via `.github/workflows/resolver-ci-nightly.yml`.
 
 ## Glossary & Appendix
 - **PIN / PA:** `metric=in_need` (People in Need) and `metric=affected` (People Affected) totals normalised to `unit=persons` or `persons_cases` for outbreaks.

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,30 @@ ctx:
 
 ctx-changed:
 	python tools/context_pack.py --base $(shell git describe --tags --abbrev=0 2>/dev/null || echo origin/main)
+
+PY ?= $(if $(PY_BIN),$(PY_BIN),python)
+
+.PHONY: dev-setup dev-setup-online dev-setup-offline test-db which-python
+
+which-python:
+	@echo "PY=$(PY)"
+	@$(PY) -c "import sys; print('sys.executable', sys.executable)"
+
+dev-setup:
+	@echo ">> Installing DB test deps (offline-first) with $(PY)"
+	@$(MAKE) which-python
+	@$(MAKE) dev-setup-offline || $(MAKE) dev-setup-online
+	@$(PY) -c "import duckdb, sys; print('duckdb installed:', duckdb.__version__, 'via', sys.executable)"
+
+dev-setup-offline:
+	@echo ">> Attempting offline wheel install from tools/offline_wheels"
+	$(PY) -m pip install --upgrade pip
+	$(PY) -m pip install --no-index --find-links tools/offline_wheels -r tools/offline_wheels/constraints-db.txt
+
+dev-setup-online:
+	@echo ">> Falling back to online install"
+	$(PY) -m pip install --upgrade pip
+	- $(PY) -m pip install -e ".[db]" || $(PY) -m pip install duckdb pytest
+
+test-db:
+	RESOLVER_API_BACKEND=db RESOLVER_DB_URL=duckdb:///resolver.dev.duckdb $(PY) -m pytest -q resolver/tests/test_db_query_contract.py

--- a/README.md
+++ b/README.md
@@ -139,6 +139,86 @@ and a corresponding `snapshots` row. Leave `RESOLVER_DB_URL` unset to continue
 operating in file-only mode; all tooling falls back automatically when the
 variable is absent.
 
+The exporter writes the very same dataframe that is saved to `facts.csv` into
+DuckDB to guarantee row-for-row parity. During these writes the DuckDB helper
+aliases staging-era columns such as `series_semantics_out` to the canonical
+`series_semantics` field (and lets the alias win whenever the canonical column
+is blank) while silently dropping any unexpected debug columns so upserts stay
+resilient when schemas drift.
+
+### DB backend tests
+
+You can exercise the DuckDB-backed contract test either completely offline or
+through a corporate proxy.
+
+#### Offline workflow (recommended for blocked networks)
+
+```bash
+# One-time on a machine with internet access (skip if wheels already tracked)
+python scripts/download_db_wheels.py
+git add tools/offline_wheels/*.whl
+git commit -m "chore: refresh offline duckdb wheels"
+
+# On the offline/proxied machine
+scripts/install_db_extra_offline.sh
+export RESOLVER_DB_URL='duckdb:///resolver.duckdb'
+export RESOLVER_API_BACKEND='db'
+pytest -q resolver/tests/test_db_query_contract.py
+```
+
+On Windows PowerShell use the `.ps1` installer and `set`-style environment
+variables:
+
+```powershell
+# Refresh wheels on a machine with internet (skip if wheels already tracked)
+python scripts/download_db_wheels.py
+git add tools/offline_wheels/*.whl
+git commit -m "chore: refresh offline duckdb wheels"
+
+# Install and run tests offline
+scripts/install_db_extra_offline.ps1
+$env:RESOLVER_DB_URL = 'duckdb:///resolver.duckdb'
+$env:RESOLVER_API_BACKEND = 'db'
+pytest -q resolver/tests/test_db_query_contract.py
+```
+
+#### Proxy-based install (if allowed)
+
+Configure proxy variables before calling pip:
+
+```bash
+export HTTPS_PROXY="http://user:pass@proxy.host:port"
+export HTTP_PROXY="http://user:pass@proxy.host:port"
+python -m pip install duckdb pytest
+```
+
+```powershell
+$env:HTTPS_PROXY = 'http://user:pass@proxy.host:port'
+$env:HTTP_PROXY = 'http://user:pass@proxy.host:port'
+python -m pip install duckdb pytest
+```
+
+You can also persist the proxy settings via pip configuration files, e.g.
+`~/.pip/pip.conf` on Unix-like systems or `%APPDATA%\pip\pip.ini` on Windows:
+
+```
+[global]
+proxy = http://user:pass@proxy.host:port
+```
+
+#### Run DB parity test in a Dev Container
+
+- Open the repository in VS Code and choose **Reopen in Container** (requires the Dev Containers extension).
+- During container creation, `.devcontainer/postCreate.sh` runs and installs DuckDB with the same interpreter that VS Code uses. It tries the vendored wheels in [`tools/offline_wheels/`](tools/offline_wheels/README.md) first and falls back to the online extras if needed. The setup logs should print `duckdb installed: <version>`.
+- Once the container is ready, run `make test-db` to execute the parity test.
+- Expected outcome: the test runs (not skipped). If it still skips, open a terminal and run:
+  ```
+  make which-python
+  python -c "import sys; print(sys.executable)"
+  python -c "import duckdb; print(duckdb.__version__)"
+  ```
+  Ensure the interpreter path matches `/usr/local/bin/python`. If it does not, update `PY_BIN` in `.devcontainer/devcontainer.json`, rebuild the container, and reopen it.
+
 What Forecaster Does (Pipeline)
 
 Select question(s)

--- a/SCHEMAS.md
+++ b/SCHEMAS.md
@@ -17,6 +17,11 @@
 > `duckdb:///resolver/db/resolver.duckdb`) to mirror resolver exports and
 > snapshots into the tables documented below. When unset, the tooling remains
 > file-backed only.
+>
+> **Writer behaviour:** the DuckDB loader aliases the staging column
+> `series_semantics_out` to the canonical `series_semantics` field and ignores
+> unexpected debug columns during upserts so schema drift does not interrupt
+> exports.
 
 ## db.facts_deltas
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1114,7 +1114,7 @@ trio = ["trio (>=0.22.0,<1.0)"]
 name = "httpx"
 version = "0.28.1"
 description = "The next generation HTTP client."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
@@ -2957,7 +2957,7 @@ windows-terminal = ["colorama (>=0.4.6)"]
 name = "pytest"
 version = "8.4.1"
 description = "pytest: simple powerful testing with Python"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
@@ -4422,4 +4422,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "901ce8de4bfce088c7fb12609ddd6f467071828dcecc7bdd0b9a505a524207cf"
+content-hash = "662f68e8618f00e6a3f49ad84baf9c6ec5b0cee66734afc21d342a145cbfdd18"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 description = ""
 authors = ["Vasile Popescu <elisescu@elisescu.com>"]
 readme = "README.md"
-package-mode = false
+packages = [
+    { include = "resolver" }
+]
 
 [tool.poetry.dependencies]
 python = "^3.11"
@@ -15,10 +17,17 @@ numpy = "^2.3.0"
 openai = "^1.57.4"
 python-dotenv = "^1.0.1"
 forecasting-tools = "^0.2.54"
+duckdb = {version = ">=0.10,<1.0", optional = true}
+httpx = {version = ">=0.27,<1.0", optional = true}
+pytest = {version = ">=8.2,<9.0", optional = true}
 
 [tool.poetry.group.dev.dependencies]
 ipykernel = "^6.29.5"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core>=1.6.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.extras]
+db = ["duckdb"]
+test = ["httpx", "pytest"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    allow_network: tests that intentionally make network calls

--- a/resolver/README.md
+++ b/resolver/README.md
@@ -224,20 +224,28 @@ All rows in `deltas.csv` are monthly "new" values with provenance. Stock series 
 
 ## DuckDB query layer
 
-The resolver CLI and API can read from either the file-backed exports or the
-DuckDB database. Set `RESOLVER_DB_URL` (or pass `--backend db`) to force database
-reads; leave unset to stay on the historical file workflow.
+The resolver CLI and API read from the historical file-backed exports by
+default. Opt into the DuckDB database by pointing at the database URL and
+selecting the backend explicitly.
 
 ```bash
-# CLI (auto-detect DB when RESOLVER_DB_URL is set)
+# CLI (default files; use --backend db or RESOLVER_CLI_BACKEND=db)
 python resolver/cli/resolver_cli.py \
   --iso3 PHL --hazard_code TC --cutoff 2024-02-29 --series new --backend db --json_only
 
-# API (uvicorn example)
+# API (uvicorn example; override default with RESOLVER_API_BACKEND=db)
 RESOLVER_DB_URL=duckdb:///$(pwd)/resolver/db/resolver.duckdb \
+  RESOLVER_API_BACKEND=db \
   uvicorn resolver.api.app:app --reload
 # GET /resolve?iso3=PHL&hazard_code=TC&cutoff=2024-02-29&series=new&backend=db
 ```
+
+Environment toggles:
+
+- `RESOLVER_CLI_BACKEND`: choose `files`, `db`, or `auto` (prefer DB when
+  available). Defaults to `files` for backwards compatibility.
+- `RESOLVER_API_BACKEND`: same options for the API default backend; the query
+  parameter `backend=` always wins when provided.
 
 When `RESOLVER_DB_URL` is set, exports and freezer scripts remain backwards
 compatible: files continue to be written for downstream consumers while the

--- a/resolver/db/duckdb_io.py
+++ b/resolver/db/duckdb_io.py
@@ -6,6 +6,7 @@ import json
 import os
 import uuid
 import datetime as dt
+import logging
 from pathlib import Path
 from typing import Iterable, Mapping, Sequence
 
@@ -23,6 +24,16 @@ SCHEMA_PATH = ROOT / "db" / "schema.sql"
 DEFAULT_DB_URL = os.environ.get(
     "RESOLVER_DB_URL", f"duckdb:///{ROOT / 'db' / 'resolver.duckdb'}"
 )
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def _quote_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
 
 
 def _normalise_db_url(path_or_url: str | None) -> str:
@@ -78,19 +89,69 @@ def upsert_dataframe(
         return 0
 
     frame = df.copy()
-    for column in frame.columns:
-        if frame[column].dtype == "object":
-            frame[column] = frame[column].astype(str)
+
+    if "series_semantics_out" in frame.columns:
+        semantics_out = frame["series_semantics_out"].where(
+            frame["series_semantics_out"].notna(), ""
+        ).astype(str)
+        if "series_semantics" in frame.columns:
+            semantics_current_raw = frame["series_semantics"]
+            semantics_current = semantics_current_raw.astype(str)
+            prefer_out = semantics_current_raw.isna() | semantics_current.str.strip().eq("")
+            frame.loc[prefer_out, "series_semantics"] = semantics_out.loc[prefer_out]
+        else:
+            frame["series_semantics"] = semantics_out
+        frame = frame.drop(columns=["series_semantics_out"])
+
+    table_info = conn.execute(f"PRAGMA table_info({_quote_literal(table)})").fetchall()
+    if not table_info:
+        raise ValueError(f"Table '{table}' does not exist in DuckDB database")
+    table_columns = [row[1] for row in table_info]
+
+    insert_columns = [col for col in frame.columns if col in table_columns]
+    dropped = [col for col in frame.columns if col not in table_columns]
+    if dropped:
+        LOGGER.debug("Dropping columns not present in %s: %s", table, ", ".join(dropped))
+    if not insert_columns:
+        raise ValueError(f"No matching columns to insert into '{table}'")
+
+    frame = frame.loc[:, insert_columns].copy()
+
+    object_columns = frame.select_dtypes(include=["object"]).columns
+    for column in object_columns:
+        frame[column] = frame[column].astype(str)
+
+    if "series_semantics" in frame.columns:
+        semantics = frame["series_semantics"].astype(str)
+        normalised = semantics.str.strip().str.lower()
+        frame.loc[normalised.str.startswith("new"), "series_semantics"] = "new"
+        frame.loc[normalised.str.startswith("stock"), "series_semantics"] = "stock"
+
     temp_name = f"tmp_{uuid.uuid4().hex}"
     conn.register(temp_name, frame)
     try:
         if keys:
+            missing_keys = [k for k in keys if k not in insert_columns]
+            if missing_keys:
+                raise KeyError(
+                    f"Upsert keys {missing_keys} are missing from dataframe for table '{table}'"
+                )
             comparisons = " AND ".join(
-                f"coalesce(t.{k}, '') = coalesce(s.{k}, '')" for k in keys
+                f"coalesce(t.{_quote_identifier(k)}, '') = coalesce(s.{_quote_identifier(k)}, '')"
+                for k in keys
             )
-            delete_sql = f"DELETE FROM {table} t USING {temp_name} s WHERE {comparisons}"
+            table_ident = _quote_identifier(table)
+            temp_ident = _quote_identifier(temp_name)
+            delete_sql = (
+                f"DELETE FROM {table_ident} AS t USING {temp_ident} AS s WHERE {comparisons}"
+            )
             conn.execute(delete_sql)
-        insert_sql = f"INSERT INTO {table} BY NAME SELECT * FROM {temp_name}"
+        cols_csv = ", ".join(_quote_identifier(col) for col in insert_columns)
+        table_ident = _quote_identifier(table)
+        temp_ident = _quote_identifier(temp_name)
+        insert_sql = (
+            f"INSERT INTO {table_ident} ({cols_csv}) SELECT {cols_csv} FROM {temp_ident}"
+        )
         conn.execute(insert_sql)
     finally:
         conn.unregister(temp_name)

--- a/resolver/tests/test_db_query_contract.py
+++ b/resolver/tests/test_db_query_contract.py
@@ -8,7 +8,13 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-pytest.importorskip("duckdb")
+pytest.importorskip(
+    "duckdb",
+    reason=(
+        "duckdb not installed. Install via extras: `pip install .[db]` or offline: "
+        "`scripts/install_db_extra_offline.(sh|ps1)`"
+    ),
+)
 pytest.importorskip("fastapi")
 
 from fastapi.testclient import TestClient

--- a/resolver/tests/test_duckdb_upsert_robust.py
+++ b/resolver/tests/test_duckdb_upsert_robust.py
@@ -1,0 +1,46 @@
+import pandas as pd
+import pytest
+
+pytest.importorskip("duckdb")
+
+from resolver.db import duckdb_io
+
+
+def test_upsert_handles_unknown_columns_and_alias(tmp_path):
+    db_path = tmp_path / "test.duckdb"
+    conn = duckdb_io.get_db(f"duckdb:///{db_path}")
+    try:
+        duckdb_io.init_schema(conn)
+        df = pd.DataFrame(
+            [
+                {
+                    "ym": "2024-01",
+                    "iso3": "PHL",
+                    "hazard_code": "TC",
+                    "metric": "in_need",
+                    "value_new": 1500,
+                    "value_stock": 1200,
+                    "series_semantics": "",
+                    "series_semantics_out": "new",
+                    "as_of": "2024-01-31",
+                    "source_name": "OCHA",
+                    "source_url": "https://example.org",
+                    "definition_text": "Pin",
+                    "unknown_debug_col": "ignore-me",
+                }
+            ]
+        )
+
+        inserted = duckdb_io.upsert_dataframe(
+            conn,
+            "facts_deltas",
+            df,
+            keys=["ym", "iso3", "hazard_code", "metric"],
+        )
+        assert inserted == 1
+        rows = conn.execute(
+            "SELECT ym, iso3, hazard_code, metric, series_semantics, value_new FROM facts_deltas"
+        ).fetchall()
+        assert rows == [("2024-01", "PHL", "TC", "in_need", "new", 1500.0)]
+    finally:
+        conn.close()

--- a/resolver/tests/test_exporter_db_parity_smoke.py
+++ b/resolver/tests/test_exporter_db_parity_smoke.py
@@ -1,0 +1,98 @@
+import json
+import sys
+
+import pandas as pd
+import pytest
+
+pytest.importorskip("duckdb")
+
+from resolver.db import duckdb_io
+
+
+def test_exporter_dual_write_matches_csv(tmp_path, monkeypatch):
+    staging = tmp_path / "staging.csv"
+    data = pd.DataFrame(
+        [
+            {
+                "event_id": "E1",
+                "country_name": "Philippines",
+                "iso3": "PHL",
+                "hazard_code": "TC",
+                "hazard_label": "Tropical Cyclone",
+                "hazard_class": "Cyclone",
+                "metric": "in_need",
+                "value": "1000",
+                "unit": "persons",
+                "as_of_date": "2024-01-15",
+                "publication_date": "2024-01-16",
+                "publisher": "OCHA",
+                "source_type": "situation_report",
+                "source_url": "https://example.org/tc",
+                "doc_title": "Report TC",
+                "definition_text": "People in need",
+                "method": "reported",
+                "confidence": "medium",
+                "revision": "1",
+                "ingested_at": "2024-01-16T00:00:00Z",
+            },
+            {
+                "event_id": "E2",
+                "country_name": "Philippines",
+                "iso3": "PHL",
+                "hazard_code": "EQ",
+                "hazard_label": "Earthquake",
+                "hazard_class": "Geophysical",
+                "metric": "affected",
+                "value": "500",
+                "unit": "persons",
+                "as_of_date": "2024-01-10",
+                "publication_date": "2024-01-11",
+                "publisher": "OCHA",
+                "source_type": "situation_report",
+                "source_url": "https://example.org/eq",
+                "doc_title": "Report EQ",
+                "definition_text": "People affected",
+                "method": "reported",
+                "confidence": "high",
+                "revision": "1",
+                "ingested_at": "2024-01-11T00:00:00Z",
+            },
+        ]
+    )
+    data.to_csv(staging, index=False)
+
+    mapping = {column: [column] for column in data.columns}
+    config = {"mapping": mapping, "constants": {}}
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(json.dumps(config))
+
+    out_dir = tmp_path / "exports"
+    out_dir.mkdir()
+
+    db_path = tmp_path / "resolver.duckdb"
+    monkeypatch.setenv("RESOLVER_DB_URL", f"duckdb:///{db_path}")
+
+    module = __import__("resolver.tools.export_facts", fromlist=["main"])
+    argv = [
+        "export_facts",
+        "--in",
+        str(staging),
+        "--config",
+        str(config_path),
+        "--out",
+        str(out_dir),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    module.main()
+
+    csv_df = pd.read_csv(out_dir / "facts.csv")
+    conn = duckdb_io.get_db(f"duckdb:///{db_path}")
+    try:
+        rows = conn.execute(
+            "SELECT event_id, iso3, hazard_code, metric FROM facts_resolved ORDER BY event_id"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert len(rows) == len(csv_df)
+    assert sorted(row[2] for row in rows) == sorted(csv_df["hazard_code"].tolist())

--- a/resolver/tests/test_import_smoke.py
+++ b/resolver/tests/test_import_smoke.py
@@ -1,0 +1,4 @@
+"""Ensure the resolver package can be imported after editable installs."""
+
+def test_import_resolver():
+    import resolver  # noqa: F401

--- a/resolver/tools/export_facts.py
+++ b/resolver/tools/export_facts.py
@@ -166,48 +166,8 @@ def _apply_mapping(df: pd.DataFrame, cfg: Dict[str, Any]) -> pd.DataFrame:
 
     return out
 
-RESOLVED_DB_COLUMNS = [
-    "ym",
-    "iso3",
-    "hazard_code",
-    "hazard_label",
-    "hazard_class",
-    "metric",
-    "series_semantics",
-    "value",
-    "unit",
-    "as_of_date",
-    "publication_date",
-    "publisher",
-    "source_type",
-    "source_url",
-    "doc_title",
-    "definition_text",
-    "precedence_tier",
-    "event_id",
-    "proxy_for",
-    "confidence",
-]
-
 RESOLVED_DB_NUMERIC = {"value"}
 RESOLVED_DB_DEFAULTS = {"series_semantics": "stock"}
-
-DELTAS_DB_COLUMNS = [
-    "ym",
-    "iso3",
-    "hazard_code",
-    "metric",
-    "value_new",
-    "value_stock",
-    "series_semantics",
-    "rebase_flag",
-    "first_observation",
-    "delta_negative_clamped",
-    "as_of",
-    "source_name",
-    "source_url",
-    "definition_text",
-]
 
 DELTAS_DB_NUMERIC = {
     "value_new",
@@ -242,31 +202,17 @@ def _prepare_resolved_for_db(df: "pd.DataFrame | None") -> "pd.DataFrame | None"
         frame.loc[mask, "ym"] = _to_month(frame.loc[mask, "publication_date"])
 
     if "series_semantics" not in frame.columns:
-        frame["series_semantics"] = "stock"
+        frame["series_semantics"] = RESOLVED_DB_DEFAULTS["series_semantics"]
     semantics = frame["series_semantics"].fillna("").astype(str)
-    frame["series_semantics"] = semantics.mask(semantics.str.strip() == "", "stock")
+    frame["series_semantics"] = semantics.mask(
+        semantics.str.strip() == "",
+        RESOLVED_DB_DEFAULTS["series_semantics"],
+    )
 
     if "value" in frame.columns:
         frame["value"] = pd.to_numeric(frame["value"], errors="coerce")
 
-    prepared = pd.DataFrame(index=frame.index)
-    for column in RESOLVED_DB_COLUMNS:
-        if column in frame.columns:
-            prepared[column] = frame[column]
-        else:
-            default = RESOLVED_DB_DEFAULTS.get(column, "")
-            if column in RESOLVED_DB_NUMERIC:
-                prepared[column] = pd.Series([float("nan")] * len(frame), dtype="float64")
-            else:
-                prepared[column] = default
-
-    for column in RESOLVED_DB_COLUMNS:
-        if column in RESOLVED_DB_NUMERIC:
-            prepared[column] = pd.to_numeric(prepared[column], errors="coerce")
-        else:
-            prepared[column] = prepared[column].fillna("").astype(str)
-
-    return prepared
+    return frame
 
 
 def _prepare_deltas_for_db(df: "pd.DataFrame | None") -> "pd.DataFrame | None":
@@ -275,46 +221,39 @@ def _prepare_deltas_for_db(df: "pd.DataFrame | None") -> "pd.DataFrame | None":
 
     frame = df.copy()
 
-    if "series_semantics" not in frame.columns and "series_semantics_out" in frame.columns:
-        frame = frame.rename(columns={"series_semantics_out": "series_semantics"})
+    if "series_semantics_out" in frame.columns:
+        semantics_out = frame["series_semantics_out"].where(
+            frame["series_semantics_out"].notna(), ""
+        ).astype(str)
+        if "series_semantics" in frame.columns:
+            semantics_current_raw = frame["series_semantics"]
+            semantics_current = semantics_current_raw.astype(str)
+            prefer_out = semantics_current_raw.isna() | semantics_current.str.strip().eq("")
+            frame.loc[prefer_out, "series_semantics"] = semantics_out.loc[prefer_out]
+        else:
+            frame["series_semantics"] = semantics_out
+        frame = frame.drop(columns=["series_semantics_out"])
 
     if "ym" not in frame.columns:
         frame["ym"] = ""
     frame["ym"] = frame["ym"].fillna("").astype(str)
     mask = frame["ym"].str.len() == 0
-    if mask.any():
-        date_sources: List[str] = []
-        if "as_of" in frame.columns:
-            date_sources.append("as_of")
-        for column in date_sources:
-            frame.loc[mask, "ym"] = _to_month(frame.loc[mask, column])
-            mask = frame["ym"].str.len() == 0
-            if not mask.any():
-                break
+    if mask.any() and "as_of" in frame.columns:
+        frame.loc[mask, "ym"] = _to_month(frame.loc[mask, "as_of"])
 
     if "series_semantics" not in frame.columns:
-        frame["series_semantics"] = "new"
+        frame["series_semantics"] = DELTAS_DB_DEFAULTS["series_semantics"]
     semantics = frame["series_semantics"].fillna("").astype(str)
-    frame["series_semantics"] = semantics.mask(semantics.str.strip() == "", "new")
+    frame["series_semantics"] = semantics.mask(
+        semantics.str.strip() == "",
+        DELTAS_DB_DEFAULTS["series_semantics"],
+    )
 
-    prepared = pd.DataFrame(index=frame.index)
-    for column in DELTAS_DB_COLUMNS:
+    for column in DELTAS_DB_NUMERIC:
         if column in frame.columns:
-            prepared[column] = frame[column]
-        else:
-            default = DELTAS_DB_DEFAULTS.get(column, "")
-            if column in DELTAS_DB_NUMERIC:
-                prepared[column] = pd.Series([float("nan")] * len(frame), dtype="float64")
-            else:
-                prepared[column] = default
+            frame[column] = pd.to_numeric(frame[column], errors="coerce")
 
-    for column in DELTAS_DB_COLUMNS:
-        if column in DELTAS_DB_NUMERIC:
-            prepared[column] = pd.to_numeric(prepared[column], errors="coerce")
-        else:
-            prepared[column] = prepared[column].fillna("").astype(str)
-
-    return prepared
+    return frame
 
 
 def _maybe_write_to_db(

--- a/scripts/download_db_wheels.py
+++ b/scripts/download_db_wheels.py
@@ -1,0 +1,40 @@
+"""Download DuckDB-related wheels for offline installation.
+
+Run this script on a machine with internet access to refresh the offline wheel
+cache committed under ``tools/offline_wheels``.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REQS = [
+    "duckdb==0.10.3",
+    "pytest==8.3.2",
+]
+
+
+def main() -> None:
+    target = Path("tools/offline_wheels").resolve()
+    target.mkdir(parents=True, exist_ok=True)
+
+    constraints = target / "constraints-db.txt"
+    cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "download",
+        "--dest",
+        str(target),
+        "--constraint",
+        str(constraints),
+    ] + REQS
+
+    print(f"Downloading wheels to {target}")
+    subprocess.check_call(cmd)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/install_db_extra_offline.ps1
+++ b/scripts/install_db_extra_offline.ps1
@@ -1,0 +1,6 @@
+Param(
+  [string]$WheelDir = "tools/offline_wheels"
+)
+
+python -m pip install --upgrade pip
+python -m pip install --no-index --find-links $WheelDir -r "$WheelDir/constraints-db.txt"

--- a/scripts/install_db_extra_offline.sh
+++ b/scripts/install_db_extra_offline.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WHEEL_DIR="${WHEEL_DIR:-tools/offline_wheels}"
+
+python -m pip install --upgrade pip
+python -m pip install --no-index --find-links "$WHEEL_DIR" -r "$WHEEL_DIR/constraints-db.txt"

--- a/tools/offline_wheels/README.md
+++ b/tools/offline_wheels/README.md
@@ -1,0 +1,27 @@
+# Offline DuckDB Wheels
+
+This directory stores pre-downloaded wheels that enable installing the resolver's
+DB testing dependencies without requiring outbound internet access. Two usage
+patterns are supported:
+
+## Offline cache (recommended)
+
+1. On a machine with internet connectivity, run `python scripts/download_db_wheels.py`
+   to refresh the cached wheel set.
+2. Commit the downloaded `*.whl` files along with this README so team members on
+   restricted networks can install the dependencies directly from source
+   control.
+3. On an offline or behind-proxy machine, execute
+   `scripts/install_db_extra_offline.sh` (or the PowerShell variant) to install
+   from the cached wheels using `pip --no-index --find-links`.
+
+## Proxy-assisted install (alternative)
+
+If corporate policy allows proxy-based access, configure the `HTTP_PROXY` and
+`HTTPS_PROXY` environment variables (or a `pip.conf`/`pip.ini` file) so pip can
+reach PyPI directly. The repository README documents sample commands for Linux,
+macOS, and Windows environments.
+
+Keep this directory small: only DuckDB, pytest, and other DB-contract-test
+requirements should be cached here. Refresh the wheels whenever versions bump in
+CI to maintain parity between offline installs and automated jobs.

--- a/tools/offline_wheels/constraints-db.txt
+++ b/tools/offline_wheels/constraints-db.txt
@@ -1,0 +1,3 @@
+# Pin versions for offline cache; update if CI upgrades dependencies.
+duckdb==0.10.3
+pytest==8.3.2


### PR DESCRIPTION
## Summary
- make DuckDB upserts prefer `series_semantics_out` values when the canonical column is blank while still dropping unknown fields and normalising semantics values
- keep the exporter’s dual-write path in lockstep with the CSV output and allow staged semantics aliases to backfill missing values before writing deltas
- add regression coverage that exercises the resilient upsert path and ensures the exporter writes the same rows to DuckDB as it emits in `facts.csv`

## Testing
- pytest resolver/tests/test_duckdb_upsert_robust.py -rs


------
https://chatgpt.com/codex/tasks/task_e_68e3cc3411b4832c980e8061250cf830