### PR TITLE
Fix resolver CI workflow YAML quoting

### DIFF
--- a/.github/workflows/resolver-ci-fast.yml
+++ b/.github/workflows/resolver-ci-fast.yml
@@ -44,7 +44,7 @@ jobs:
           echo "GITHUB_SHA=$GITHUB_SHA"
           python -c "import pathlib; p = pathlib.Path().resolve(); print('CWD:', p); print('Tree:', len(list(p.glob('**/*'))))"
 
-      - name: Anti-drift: assert no legacy repo references
+      - name: "Anti-drift: assert no legacy repo references"
         run: |
           part_a="spa"
           part_b="gbot"

--- a/.github/workflows/resolver-ci-nightly.yml
+++ b/.github/workflows/resolver-ci-nightly.yml
@@ -50,7 +50,7 @@ jobs:
           echo "GITHUB_REF=$GITHUB_REF"
           echo "GITHUB_SHA=$GITHUB_SHA"
           python -c "import pathlib; p = pathlib.Path().resolve(); print('CWD:', p); print('Tree:', len(list(p.glob('**/*'))))"
-      - name: Anti-drift: assert no legacy repo references
+      - name: "Anti-drift: assert no legacy repo references"
         run: |
           part_a="spa"
           part_b="gbot"
@@ -225,7 +225,7 @@ jobs:
           echo "GITHUB_SHA=$GITHUB_SHA"
           python -c "import pathlib; p = pathlib.Path().resolve(); print('CWD:', p); print('Tree:', len(list(p.glob('**/*'))))"
 
-      - name: Anti-drift: assert no legacy repo references
+      - name: "Anti-drift: assert no legacy repo references"
         run: |
           part_a="spa"
           part_b="gbot"

--- a/.github/workflows/resolver-ci.yml
+++ b/.github/workflows/resolver-ci.yml
@@ -34,7 +34,7 @@ jobs:
           echo "GITHUB_SHA=$GITHUB_SHA"
           python -c "import pathlib; p = pathlib.Path().resolve(); print('CWD:', p); print('Tree:', len(list(p.glob('**/*'))))"
 
-      - name: Anti-drift: assert no legacy repo references
+      - name: "Anti-drift: assert no legacy repo references"
         run: |
           part_a="spa"
           part_b="gbot"
@@ -138,7 +138,7 @@ jobs:
           echo "GITHUB_SHA=$GITHUB_SHA"
           python -c "import pathlib; p = pathlib.Path().resolve(); print('CWD:', p); print('Tree:', len(list(p.glob('**/*'))))"
 
-      - name: Anti-drift: assert no legacy repo references
+      - name: "Anti-drift: assert no legacy repo references"
         run: |
           part_a="spa"
           part_b="gbot"


### PR DESCRIPTION
## Summary
- quote the Anti-drift step names in each resolver CI workflow so GitHub can parse the YAML correctly

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e611226888832c96f2939195cd44a3