### PR TITLE
Handle resolver DB workflows without hashFiles checks

### DIFF
--- a/.github/workflows/resolver-ci-fast.yml
+++ b/.github/workflows/resolver-ci-fast.yml
@@ -44,7 +44,7 @@ jobs:
           echo "GITHUB_SHA=$GITHUB_SHA"
           python -c "import pathlib; p = pathlib.Path().resolve(); print('CWD:', p); print('Tree:', len(list(p.glob('**/*'))))"
 
-      - name: Anti-drift: assert no legacy repo references
+      - name: "Anti-drift: assert no legacy repo references"
         run: |
           part_a="spa"
           part_b="gbot"
@@ -95,7 +95,7 @@ jobs:
           path: pytest-junit.xml
 
   db_tests:
-    if: ${{ hashFiles('resolver/tests/test_db_parity.py', 'resolver/tests/test_duckdb_idempotency.py') != '' }}
+    if: ${{ github.repository == 'oughtinc/Pythia' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -103,19 +103,34 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-
       - name: Debug repo context
         run: |
           echo "Repo=$GITHUB_REPOSITORY Ref=$GITHUB_REF SHA=$GITHUB_SHA"
           python -c "import pathlib; print('CWD=', pathlib.Path().resolve())"
 
+      - name: Check DB tests present
+        id: dbfiles
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -f "resolver/tests/test_db_parity.py" ] || [ -f "resolver/tests/test_duckdb_idempotency.py" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+            echo "Found DB tests."
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "No DB tests found; will skip DB test steps."
+          fi
+
+      - name: Setup Python
+        if: steps.dbfiles.outputs.present == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
       - name: Install (robust, proxy-safe) with fallback
         id: robust_install
+        if: steps.dbfiles.outputs.present == 'true'
         shell: bash
         env:
           PIP_NO_CACHE_DIR: "1"
@@ -146,14 +161,18 @@ jobs:
           echo "mode=fallback" >>"$GITHUB_OUTPUT"
 
       - name: Run DuckDB tests (editable)
-        if: steps.robust_install.outputs.mode == 'editable'
+        if: steps.dbfiles.outputs.present == 'true' && steps.robust_install.outputs.mode == 'editable'
         env:
           RESOLVER_DB_URL: duckdb:///${{ runner.temp }}/resolver.ci.duckdb
         run: python -m pytest -q resolver/tests/test_db_parity.py resolver/tests/test_duckdb_idempotency.py
 
       - name: Run DuckDB tests (fallback, PYTHONPATH)
-        if: steps.robust_install.outputs.mode == 'fallback'
+        if: steps.dbfiles.outputs.present == 'true' && steps.robust_install.outputs.mode == 'fallback'
         env:
           PYTHONPATH: ${{ github.workspace }}
           RESOLVER_DB_URL: duckdb:///${{ runner.temp }}/resolver.ci.duckdb
         run: python -m pytest -q resolver/tests/test_db_parity.py resolver/tests/test_duckdb_idempotency.py
+
+      - name: Skip DB tests (not present)
+        if: steps.dbfiles.outputs.present != 'true'
+        run: echo "::notice ::Skipping DB tests (files not present in this repo/branch)."

--- a/.github/workflows/resolver-ci-nightly.yml
+++ b/.github/workflows/resolver-ci-nightly.yml
@@ -14,11 +14,7 @@ concurrency:
 
 jobs:
   full_connectors:
-    if: >
-      ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.repository == 'oughtinc/Pythia' && (
-          hashFiles('resolver/tests/test_db_parity.py') != '' ||
-          hashFiles('resolver/tests/test_duckdb_idempotency.py') != ''
-      ) }}
+    if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.repository == 'oughtinc/Pythia' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -50,7 +46,22 @@ jobs:
           echo "GITHUB_REF=$GITHUB_REF"
           echo "GITHUB_SHA=$GITHUB_SHA"
           python -c "import pathlib; p = pathlib.Path().resolve(); print('CWD:', p); print('Tree:', len(list(p.glob('**/*'))))"
-      - name: Anti-drift: assert no legacy repo references
+
+      - name: Check DB tests present
+        id: dbfiles
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -f "resolver/tests/test_db_parity.py" ] || [ -f "resolver/tests/test_duckdb_idempotency.py" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+            echo "Found DB tests."
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "No DB tests found; will skip DB test steps."
+          fi
+
+      - name: "Anti-drift: assert no legacy repo references"
+        if: steps.dbfiles.outputs.present == 'true'
         run: |
           part_a="spa"
           part_b="gbot"
@@ -58,6 +69,7 @@ jobs:
           chmod +x "$script_path"
           "$script_path"
       - name: Set up Python
+        if: steps.dbfiles.outputs.present == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -66,8 +78,10 @@ jobs:
             resolver/requirements.txt
             resolver/requirements-dev.txt
       - name: Confirm Pythia root
+        if: steps.dbfiles.outputs.present == 'true'
         run: ls -la && test -f pyproject.toml
       - name: Install dependencies
+        if: steps.dbfiles.outputs.present == 'true'
         env:
           PIP_NO_CACHE_DIR: "1"
         run: |
@@ -77,6 +91,7 @@ jobs:
           pip install -r resolver/requirements-dev.txt
 
       - name: Verify DuckDB presence
+        if: steps.dbfiles.outputs.present == 'true'
         run: |
           python - <<'PY'
           import importlib.util, sys
@@ -88,11 +103,13 @@ jobs:
           print("✅ DuckDB installed:", duckdb.__version__)
           PY
       - name: Run ${{ matrix.connector }} (full)
+        if: steps.dbfiles.outputs.present == 'true'
         env:
           RESOLVER_FAIL_ON_STUB_ERROR: "0"
         run: |
           python -m resolver.ingestion.run_all_stubs --mode real --only ${{ matrix.connector }} --log-level INFO --log-format json
       - name: Run staging schema tests
+        if: steps.dbfiles.outputs.present == 'true'
         run: pytest -q resolver/tests/test_staging_schema_all.py
       - name: Record job status
         if: always()
@@ -122,6 +139,10 @@ jobs:
             resolver/exports/**
             resolver/staging/**
           retention-days: 7
+
+      - name: Skip DB tests (not present)
+        if: steps.dbfiles.outputs.present != 'true'
+        run: echo "::notice ::Skipping nightly connectors (DB tests not present in this repo/branch)."
 
   aggregate:
     if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
@@ -204,11 +225,7 @@ jobs:
 
   tests-db:
     name: tests (db backend)
-    if: >
-      ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.repository == 'oughtinc/Pythia' && (
-          hashFiles('resolver/tests/test_db_parity.py') != '' ||
-          hashFiles('resolver/tests/test_duckdb_idempotency.py') != ''
-      ) }}
+    if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.repository == 'oughtinc/Pythia' }}
     runs-on: ubuntu-latest
     env:
       RESOLVER_API_BACKEND: db
@@ -225,7 +242,21 @@ jobs:
           echo "GITHUB_SHA=$GITHUB_SHA"
           python -c "import pathlib; p = pathlib.Path().resolve(); print('CWD:', p); print('Tree:', len(list(p.glob('**/*'))))"
 
-      - name: Anti-drift: assert no legacy repo references
+      - name: Check DB tests present
+        id: dbfiles
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -f "resolver/tests/test_db_parity.py" ] || [ -f "resolver/tests/test_duckdb_idempotency.py" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+            echo "Found DB tests."
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "No DB tests found; will skip DB test steps."
+          fi
+
+      - name: "Anti-drift: assert no legacy repo references"
+        if: steps.dbfiles.outputs.present == 'true'
         run: |
           part_a="spa"
           part_b="gbot"
@@ -234,12 +265,14 @@ jobs:
           "$script_path"
 
       - name: Set up Python
+        if: steps.dbfiles.outputs.present == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Cache pip
         uses: actions/cache@v4
+        if: steps.dbfiles.outputs.present == 'true'
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-db-${{ hashFiles('pyproject.toml', 'resolver/requirements.txt', 'resolver/requirements-dev.txt', 'tools/offline_wheels/constraints-db.txt') }}
@@ -247,9 +280,11 @@ jobs:
             ${{ runner.os }}-pip-db-
 
       - name: Confirm Pythia root
+        if: steps.dbfiles.outputs.present == 'true'
         run: ls -la && test -f pyproject.toml
 
       - name: Install resolver dependencies (db backend)
+        if: steps.dbfiles.outputs.present == 'true'
         env:
           PIP_NO_CACHE_DIR: "1"
         run: |
@@ -260,6 +295,7 @@ jobs:
           pip install httpx pytest
 
       - name: Verify DuckDB presence
+        if: steps.dbfiles.outputs.present == 'true'
         run: |
           python - <<'PY'
           import importlib.util, sys
@@ -272,6 +308,7 @@ jobs:
           PY
 
       - name: Show environment
+        if: steps.dbfiles.outputs.present == 'true'
         run: |
           python -V
           python -c "import duckdb,sys;print('duckdb',duckdb.__version__)"
@@ -279,8 +316,13 @@ jobs:
           echo "DB_URL=$RESOLVER_DB_URL"
 
       - name: Run tests (db)
+        if: steps.dbfiles.outputs.present == 'true'
         run: |
           pytest -q
+
+      - name: Skip DB tests (not present)
+        if: steps.dbfiles.outputs.present != 'true'
+        run: echo "::notice ::Skipping DB tests (files not present in this repo/branch)."
       - name: Upload DB parity diagnostics
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/resolver-ci.yml
+++ b/.github/workflows/resolver-ci.yml
@@ -34,7 +34,7 @@ jobs:
           echo "GITHUB_SHA=$GITHUB_SHA"
           python -c "import pathlib; p = pathlib.Path().resolve(); print('CWD:', p); print('Tree:', len(list(p.glob('**/*'))))"
 
-      - name: Anti-drift: assert no legacy repo references
+      - name: "Anti-drift: assert no legacy repo references"
         run: |
           part_a="spa"
           part_b="gbot"
@@ -118,11 +118,7 @@ jobs:
   tests-db:
     name: tests (db backend)
     runs-on: ubuntu-latest
-    if: >
-      ${{ github.repository == 'oughtinc/Pythia' && (
-          hashFiles('resolver/tests/test_db_parity.py') != '' ||
-          hashFiles('resolver/tests/test_duckdb_idempotency.py') != ''
-      ) }}
+    if: ${{ github.repository == 'oughtinc/Pythia' }}
     env:
       RESOLVER_API_BACKEND: db
       RESOLVER_DB_URL: duckdb:///${{ github.workspace }}/.ci-resolver.duckdb
@@ -138,7 +134,20 @@ jobs:
           echo "GITHUB_SHA=$GITHUB_SHA"
           python -c "import pathlib; p = pathlib.Path().resolve(); print('CWD:', p); print('Tree:', len(list(p.glob('**/*'))))"
 
-      - name: Anti-drift: assert no legacy repo references
+      - name: Check DB tests present
+        id: dbfiles
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -f "resolver/tests/test_db_parity.py" ] || [ -f "resolver/tests/test_duckdb_idempotency.py" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+            echo "Found DB tests."
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "No DB tests found; will skip DB test steps."
+          fi
+
+      - name: "Anti-drift: assert no legacy repo references"
         run: |
           part_a="spa"
           part_b="gbot"
@@ -150,9 +159,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+        if: steps.dbfiles.outputs.present == 'true'
 
       - name: Cache pip
         uses: actions/cache@v4
+        if: steps.dbfiles.outputs.present == 'true'
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-db-${{ hashFiles('pyproject.toml', 'resolver/requirements.txt', 'resolver/requirements-dev.txt', 'tools/offline_wheels/constraints-db.txt') }}
@@ -160,9 +171,11 @@ jobs:
             ${{ runner.os }}-pip-db-
 
       - name: Confirm Pythia root
+        if: steps.dbfiles.outputs.present == 'true'
         run: ls -la && test -f pyproject.toml
 
       - name: Install resolver dependencies (db backend)
+        if: steps.dbfiles.outputs.present == 'true'
         env:
           PIP_NO_CACHE_DIR: "1"
         run: |
@@ -173,6 +186,7 @@ jobs:
           pip install httpx pytest
 
       - name: Verify DuckDB presence
+        if: steps.dbfiles.outputs.present == 'true'
         run: |
           python - <<'PY'
           import importlib.util, sys
@@ -185,6 +199,7 @@ jobs:
           PY
 
       - name: Show environment
+        if: steps.dbfiles.outputs.present == 'true'
         run: |
           python -V
           python -c "import duckdb,sys;print('duckdb',duckdb.__version__)"
@@ -192,8 +207,13 @@ jobs:
           echo "DB_URL=$RESOLVER_DB_URL"
 
       - name: Run tests (db)
+        if: steps.dbfiles.outputs.present == 'true'
         run: |
           pytest -q
+
+      - name: Skip DB tests (not present)
+        if: steps.dbfiles.outputs.present != 'true'
+        run: echo "::notice ::Skipping DB tests (files not present in this repo/branch)."
       - name: Upload DB parity diagnostics
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- replace the resolver DB workflow guards that used `hashFiles()` with a repo-only condition and an explicit step to detect DB test files
- gate dependency installs and DB pytest steps on the detection result, adding skip notices when the files are missing
- update the nightly connectors matrix to reuse the detection logic while keeping the existing debug output and repo guard

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68e611226888832c96f2939195cd44a3