### PR TITLE
Improve DuckDB upsert idempotency and logging

### DIFF
--- a/resolver/tests/test_duckdb_idempotency.py
+++ b/resolver/tests/test_duckdb_idempotency.py
@@ -243,8 +243,9 @@ def test_delete_logging(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> Non
     )
     conn.close()
 
+    legacy_message = "Deleted 1 existing rows from facts_resolved"
+    merge_message = "Upserted 1 rows into facts_resolved via MERGE"
     assert any(
-        ("Deleted 1 existing rows" in record.message)
-        or ("Matched 1 existing rows in facts_resolved" in record.message)
+        (legacy_message in record.message) or (merge_message in record.message)
         for record in caplog.records
     )


### PR DESCRIPTION
## Summary
- detect declared primary/unique keys and select MERGE or DELETE+INSERT upsert strategy accordingly
- stabilise DuckDB upsert logging and extend diagnostics while handling NameError failures safely
- update idempotency test expectations to allow either MERGE or legacy delete logging

## Testing
- pytest -q resolver/tests/test_duckdb_idempotency.py -k test_dual_writes_idempotent -vv
- pytest -q resolver/tests/test_duckdb_idempotency.py -k test_delete_logging -vv

------
https://chatgpt.com/codex/tasks/task_e_68e6569a60a8832cbfaf2404c55344cd