### PR TITLE
Ensure DuckDB CI jobs run in pull requests and pushes

### DIFF
--- a/.github/workflows/resolver-ci-fast.yml
+++ b/.github/workflows/resolver-ci-fast.yml
@@ -95,7 +95,7 @@ jobs:
           path: pytest-junit.xml
 
   db_tests:
-    if: ${{ github.repository == 'oughtinc/Pythia' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -143,7 +143,7 @@ jobs:
           set -euo pipefail
           echo "Attempt A: editable install with preloaded build tooling and DuckDB wheel"
           python -m pip install -U pip wheel setuptools "poetry-core>=1.9"
-          python -m pip install --only-binary=:all: "duckdb==1.1.3" || true
+          python -m pip install --only-binary=:all: "duckdb==1.1.3"
           if python -m pip install -e ".[db]" --no-build-isolation; then
             echo "mode=editable" >>"$GITHUB_OUTPUT"
             exit 0
@@ -155,7 +155,7 @@ jobs:
             exit 0
           fi
           echo "Editable install failed; falling back to requirements with PYTHONPATH"
-          python -m pip install --only-binary=:all: "duckdb==1.1.3" || true
+          python -m pip install --only-binary=:all: "duckdb==1.1.3"
           if [ -f resolver/requirements.txt ]; then python -m pip install -r resolver/requirements.txt || true; fi
           if [ -f resolver/requirements-dev.txt ]; then python -m pip install -r resolver/requirements-dev.txt || true; fi
           if [ -f resolver/requirements-ci.txt ]; then python -m pip install -r resolver/requirements-ci.txt || true; fi

--- a/.github/workflows/resolver-ci.yml
+++ b/.github/workflows/resolver-ci.yml
@@ -116,7 +116,7 @@ jobs:
           PY
 
   tests-db:
-    if: ${{ github.repository == 'oughtinc/Pythia' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
     name: tests (db backend)
     runs-on: ubuntu-latest
     env:
@@ -180,7 +180,7 @@ jobs:
           set -euo pipefail
           echo "Attempt A: editable install with preloaded build tooling and DuckDB wheel"
           python -m pip install -U pip wheel setuptools "poetry-core>=1.9"
-          python -m pip install --only-binary=:all: "duckdb==1.1.3" || true
+          python -m pip install --only-binary=:all: "duckdb==1.1.3"
           if python -m pip install -e ".[db]" --no-build-isolation; then
             echo "mode=editable" >>"$GITHUB_OUTPUT"
             exit 0
@@ -192,7 +192,7 @@ jobs:
             exit 0
           fi
           echo "Editable install failed; falling back to requirements with PYTHONPATH"
-          python -m pip install --only-binary=:all: "duckdb==1.1.3" || true
+          python -m pip install --only-binary=:all: "duckdb==1.1.3"
           if [ -f resolver/requirements.txt ]; then python -m pip install -r resolver/requirements.txt || true; fi
           if [ -f resolver/requirements-dev.txt ]; then python -m pip install -r resolver/requirements-dev.txt || true; fi
           if [ -f resolver/requirements-ci.txt ]; then python -m pip install -r resolver/requirements-ci.txt || true; fi


### PR DESCRIPTION
## Summary
- update the resolver CI workflows so DuckDB test jobs run for pull requests and pushes instead of being gated on the repository name
- ensure the DuckDB wheel installation step fails if the wheel cannot be installed so the jobs no longer skip due to missing dependencies

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e65ae68660832cb2b6d6961b0f12f2