### PR TITLE
fix: refine summary view based on production feedback

### DIFF
--- a/pythia/api/app.py
+++ b/pythia/api/app.py
@@ -3772,6 +3772,7 @@ def diagnostics_run_summary(
         "countries_scanned": 0,
         "hazard_pairs_assessed": 0,
         "seasonal_screenouts": 0,
+        "acled_low_activity": 0,
         "pairs_with_questions": 0,
         "total_questions": 0,
         "countries_with_forecasts": 0,
@@ -3779,36 +3780,66 @@ def diagnostics_run_summary(
         "triaged_quiet": 0,
     }
 
+    has_dq_json = False
     if hs_run_id and _table_exists(con, "hs_triage"):
+        has_dq_json = "data_quality_json" in _table_columns(con, "hs_triage")
+
         coverage["countries_scanned"] = _q1(
             f"SELECT COUNT(DISTINCT UPPER(ht.iso3)) FROM hs_triage ht "
             f"WHERE ht.run_id = ?{tf_ht}",
             [hs_run_id],
         ) or 0
 
-        coverage["hazard_pairs_assessed"] = _q1(
-            f"SELECT COUNT(*) FROM hs_triage ht "
-            f"WHERE ht.run_id = ?{tf_ht} "
-            f"AND ht.regime_change_likelihood IS NOT NULL",
-            [hs_run_id],
-        ) or 0
+        # Seasonal screen-outs are marked via data_quality_json.status = 'seasonal_skip'
+        if has_dq_json:
+            coverage["seasonal_screenouts"] = _q1(
+                f"SELECT COUNT(*) FROM hs_triage ht "
+                f"WHERE ht.run_id = ?{tf_ht} "
+                f"AND ht.data_quality_json LIKE '%seasonal_skip%'",
+                [hs_run_id],
+            ) or 0
 
-        # Seasonal screen-outs: pairs where RC was NOT assessed
+            # ACLED low-activity (quiet conflict) screen-outs
+            coverage["acled_low_activity"] = _q1(
+                f"SELECT COUNT(*) FROM hs_triage ht "
+                f"WHERE ht.run_id = ?{tf_ht} "
+                f"AND ht.data_quality_json LIKE '%acled_low_activity%'",
+                [hs_run_id],
+            ) or 0
+
         total_triage_rows = _q1(
             f"SELECT COUNT(*) FROM hs_triage ht WHERE ht.run_id = ?{tf_ht}",
             [hs_run_id],
         ) or 0
-        coverage["seasonal_screenouts"] = total_triage_rows - coverage["hazard_pairs_assessed"]
 
-        # Triaged quiet: tier = 'quiet' and RC was assessed (not seasonal skip, not RC-promoted)
-        coverage["triaged_quiet"] = _q1(
-            f"SELECT COUNT(*) FROM hs_triage ht "
-            f"WHERE ht.run_id = ?{tf_ht} "
-            f"AND LOWER(ht.tier) = 'quiet' "
-            f"AND ht.regime_change_likelihood IS NOT NULL "
-            f"AND COALESCE(ht.regime_change_level, 0) = 0",
-            [hs_run_id],
-        ) or 0
+        # Hazard pairs assessed = total minus seasonal skips and ACLED low-activity
+        coverage["hazard_pairs_assessed"] = (
+            total_triage_rows
+            - coverage["seasonal_screenouts"]
+            - coverage["acled_low_activity"]
+        )
+
+        # Triaged quiet: tier = 'quiet' excluding seasonal skips, ACLED low-activity, and RC-promoted
+        if has_dq_json:
+            coverage["triaged_quiet"] = _q1(
+                f"SELECT COUNT(*) FROM hs_triage ht "
+                f"WHERE ht.run_id = ?{tf_ht} "
+                f"AND LOWER(ht.tier) = 'quiet' "
+                f"AND ht.data_quality_json NOT LIKE '%seasonal_skip%' "
+                f"AND ht.data_quality_json NOT LIKE '%acled_low_activity%' "
+                f"AND ht.data_quality_json NOT LIKE '%rc_promoted%' "
+                f"AND COALESCE(ht.regime_change_level, 0) = 0",
+                [hs_run_id],
+            ) or 0
+        else:
+            coverage["triaged_quiet"] = _q1(
+                f"SELECT COUNT(*) FROM hs_triage ht "
+                f"WHERE ht.run_id = ?{tf_ht} "
+                f"AND LOWER(ht.tier) = 'quiet' "
+                f"AND ht.regime_change_likelihood IS NOT NULL "
+                f"AND COALESCE(ht.regime_change_level, 0) = 0",
+                [hs_run_id],
+            ) or 0
 
     # Questions coverage (from questions table linked to this run)
     q_filter = ""
@@ -3946,12 +3977,16 @@ def diagnostics_run_summary(
             {"hazard_code": hc, **levels} for hc, levels in sorted(hazard_rc.items())
         ]
 
-        # Countries by level: distinct iso3 with at least one hazard at each level
+        # Countries by level: distinct iso3 where max RC level across hazards = that level
         for level_val, level_key in [(1, "L1"), (2, "L2"), (3, "L3")]:
             rc_assessment["countries_by_level"][level_key] = _q1(
-                f"SELECT COUNT(DISTINCT UPPER(ht.iso3)) FROM hs_triage ht "
-                f"WHERE ht.run_id = ?{tf_ht} "
-                f"AND COALESCE(ht.regime_change_level, 0) >= ?",
+                f"SELECT COUNT(*) FROM ("
+                f"  SELECT UPPER(ht.iso3) AS iso3 FROM hs_triage ht "
+                f"  WHERE ht.run_id = ?{tf_ht} "
+                f"  AND ht.regime_change_likelihood IS NOT NULL "
+                f"  GROUP BY UPPER(ht.iso3) "
+                f"  HAVING MAX(COALESCE(ht.regime_change_level, 0)) = ?"
+                f")",
                 [hs_run_id, level_val],
             ) or 0
 
@@ -3976,15 +4011,27 @@ def diagnostics_run_summary(
                     q_params + [track_val],
                 ) or 0
 
-    # Ensemble model count from forecasts_raw
+    # Ensemble model count from forecasts_raw (Track 1 questions only)
     if run_id and _table_exists(con, "forecasts_raw"):
         model_col = "model_name" if "model_name" in _table_columns(con, "forecasts_raw") else None
         if model_col:
-            tracks["track1"]["models"] = _q1(
-                f"SELECT COUNT(DISTINCT fr.{model_col}) FROM forecasts_raw fr "
-                f"WHERE fr.run_id = ? AND COALESCE(fr.ok, TRUE) = TRUE",
-                [run_id],
-            ) or 0
+            # Count distinct models for Track 1 questions only (exclude track2_flash, ensemble aggregation)
+            if q_filter and _table_exists(con, "questions") and "track" in _table_columns(con, "questions"):
+                tracks["track1"]["models"] = _q1(
+                    f"SELECT COUNT(DISTINCT fr.{model_col}) FROM forecasts_raw fr "
+                    f"JOIN questions q ON fr.question_id = q.question_id "
+                    f"WHERE fr.run_id = ? AND COALESCE(fr.ok, TRUE) = TRUE "
+                    f"AND q.track = 1 "
+                    f"AND fr.{model_col} NOT LIKE 'ensemble_%' "
+                    f"AND fr.{model_col} NOT LIKE 'track2_%'",
+                    [run_id],
+                ) or 0
+            else:
+                tracks["track1"]["models"] = _q1(
+                    f"SELECT COUNT(DISTINCT fr.{model_col}) FROM forecasts_raw fr "
+                    f"WHERE fr.run_id = ? AND COALESCE(fr.ok, TRUE) = TRUE",
+                    [run_id],
+                ) or 0
 
     # ---- Ensemble health --------------------------------------------------
     ensemble: Dict[str, int] = {"expected": 7, "ok": tracks["track1"]["models"]}
@@ -4032,9 +4079,9 @@ def diagnostics_run_summary(
 
             # By phase
             PHASE_LABELS = [
-                ("hs_triage", "HS triage"),
-                ("spd_v2", "SPD ensemble"),
-                ("binary_v2", "Binary forecasts"),
+                ("hs_triage", "Horizon Scan Triage and RC"),
+                ("spd_v2", "Ensemble Forecasts"),
+                ("binary_v2", "Binary Forecasts"),
                 ("scenario_v2", "Scenarios"),
             ]
             for phase_val, phase_label in PHASE_LABELS:
@@ -4055,14 +4102,17 @@ def diagnostics_run_summary(
                 lc_params,
             ) or 0
 
-            # Error detection: check for error_text or status = 'error'
+            # Error detection: check for non-empty error_text or status = 'error'
             has_error_text = "error_text" in _table_columns(con, "llm_calls")
             has_status = "status" in _table_columns(con, "llm_calls")
             error_cond = ""
             if has_error_text and has_status:
-                error_cond = " AND (lc.error_text IS NOT NULL OR lc.status = 'error')"
+                error_cond = (
+                    " AND ((lc.error_text IS NOT NULL AND lc.error_text != '')"
+                    " OR lc.status = 'error')"
+                )
             elif has_error_text:
-                error_cond = " AND lc.error_text IS NOT NULL"
+                error_cond = " AND lc.error_text IS NOT NULL AND lc.error_text != ''"
             elif has_status:
                 error_cond = " AND lc.status = 'error'"
 

--- a/tests/test_api_run_summary.py
+++ b/tests/test_api_run_summary.py
@@ -64,6 +64,7 @@ def api_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[None, 
             regime_change_likelihood DOUBLE,
             regime_change_level INTEGER,
             track INTEGER,
+            data_quality_json TEXT,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             is_test BOOLEAN DEFAULT FALSE
         )
@@ -119,30 +120,30 @@ def api_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[None, 
     hs_run = "hs_test_run_1"
     fc_run = "fc_test_run_1"
 
-    # HS triage: 3 countries x 4 hazards, with some seasonal skips
+    # HS triage: 3 countries x 4 hazards, with some seasonal skips and ACLED low-activity
     # Country A (AAA): ACE L2, DR L1, FL L0, TC seasonal skip
     # Country B (BBB): ACE L1, DR L0, FL L0, TC L0
-    # Country C (CCC): ACE L0, DR L0, FL seasonal skip, TC seasonal skip
+    # Country C (CCC): ACE acled_low_activity, DR L0, FL seasonal skip, TC seasonal skip
     triage_rows = [
-        # (run_id, iso3, hazard, tier, score, need_spd, rc_likelihood, rc_level, track)
-        (hs_run, "AAA", "ACE", "priority", 0.8, True, 0.45, 2, 1),
-        (hs_run, "AAA", "DR", "priority", 0.6, True, 0.20, 1, 1),
-        (hs_run, "AAA", "FL", "quiet", 0.1, False, 0.05, 0, 2),
-        (hs_run, "AAA", "TC", "quiet", 0.0, False, None, None, None),   # seasonal skip
-        (hs_run, "BBB", "ACE", "priority", 0.5, True, 0.18, 1, 1),
-        (hs_run, "BBB", "DR", "quiet", 0.2, False, 0.08, 0, 2),
-        (hs_run, "BBB", "FL", "quiet", 0.1, False, 0.04, 0, 2),
-        (hs_run, "BBB", "TC", "quiet", 0.1, False, 0.02, 0, 2),
-        (hs_run, "CCC", "ACE", "quiet", 0.1, False, 0.03, 0, 2),
-        (hs_run, "CCC", "DR", "quiet", 0.1, False, 0.05, 0, 2),
-        (hs_run, "CCC", "FL", "quiet", 0.0, False, None, None, None),   # seasonal skip
-        (hs_run, "CCC", "TC", "quiet", 0.0, False, None, None, None),   # seasonal skip
+        # (run_id, iso3, hazard, tier, score, need_spd, rc_likelihood, rc_level, track, dq_json)
+        (hs_run, "AAA", "ACE", "priority", 0.8, True, 0.45, 2, 1, '{"status": "rc_promoted"}'),
+        (hs_run, "AAA", "DR", "priority", 0.6, True, 0.20, 1, 1, '{"status": "rc_promoted"}'),
+        (hs_run, "AAA", "FL", "quiet", 0.1, False, 0.05, 0, 2, '{}'),
+        (hs_run, "AAA", "TC", "quiet", 0.0, False, None, None, None, '{"status": "seasonal_skip"}'),
+        (hs_run, "BBB", "ACE", "priority", 0.5, True, 0.18, 1, 1, '{"status": "rc_promoted"}'),
+        (hs_run, "BBB", "DR", "quiet", 0.2, False, 0.08, 0, 2, '{}'),
+        (hs_run, "BBB", "FL", "quiet", 0.1, False, 0.04, 0, 2, '{}'),
+        (hs_run, "BBB", "TC", "quiet", 0.1, False, 0.02, 0, 2, '{}'),
+        (hs_run, "CCC", "ACE", "quiet", 0.0, False, None, None, None, '{"status": "acled_low_activity"}'),
+        (hs_run, "CCC", "DR", "quiet", 0.1, False, 0.05, 0, 2, '{}'),
+        (hs_run, "CCC", "FL", "quiet", 0.0, False, None, None, None, '{"status": "seasonal_skip"}'),
+        (hs_run, "CCC", "TC", "quiet", 0.0, False, None, None, None, '{"status": "seasonal_skip"}'),
     ]
     for row in triage_rows:
         con.execute(
             "INSERT INTO hs_triage (run_id, iso3, hazard_code, tier, triage_score, "
-            "need_full_spd, regime_change_likelihood, regime_change_level, track) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "need_full_spd, regime_change_likelihood, regime_change_level, track, data_quality_json) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             list(row),
         )
 
@@ -182,12 +183,12 @@ def api_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[None, 
             [fc_run, model],
         )
 
-    # LLM calls
+    # LLM calls (use '' for error_text on success, non-empty string for actual errors)
     llm_rows = [
-        (fc_run, hs_run, "hs_triage", 1.50, 5000, None, "ok"),
-        (fc_run, hs_run, "spd_v2", 3.20, 12000, None, "ok"),
-        (fc_run, hs_run, "binary_v2", 0.80, 3000, None, "ok"),
-        (fc_run, hs_run, "scenario_v2", 0.10, 500, None, "ok"),
+        (fc_run, hs_run, "hs_triage", 1.50, 5000, "", "ok"),
+        (fc_run, hs_run, "spd_v2", 3.20, 12000, "", "ok"),
+        (fc_run, hs_run, "binary_v2", 0.80, 3000, "", "ok"),
+        (fc_run, hs_run, "scenario_v2", 0.10, 500, "", "ok"),
         (fc_run, hs_run, "spd_v2", 0.00, 100, "timeout error", "error"),
     ]
     for run, hs, phase, cost, tokens, err, status in llm_rows:
@@ -246,8 +247,10 @@ def test_run_summary_coverage(api_env: None) -> None:
     cov = data["coverage"]
 
     assert cov["countries_scanned"] == 3  # AAA, BBB, CCC
-    assert cov["hazard_pairs_assessed"] == 9  # 12 total - 3 seasonal skips
     assert cov["seasonal_screenouts"] == 3  # TC for AAA, FL+TC for CCC
+    assert cov["acled_low_activity"] == 1  # CCC/ACE
+    # 12 total - 3 seasonal - 1 ACLED low-activity = 8 assessed
+    assert cov["hazard_pairs_assessed"] == 8
     assert cov["total_questions"] == 10
     assert cov["countries_with_forecasts"] == 2  # AAA, BBB
     assert cov["countries_no_questions"] == 1  # CCC
@@ -277,14 +280,16 @@ def test_run_summary_rc_assessment(api_env: None) -> None:
     )
     rc = resp.json()["rc_assessment"]
 
-    assert rc["total_assessed"] == 9
-    assert rc["levels"]["L0"] == 6
+    # 12 total rows, but only those with regime_change_likelihood IS NOT NULL are assessed
+    # Seasonal skips (3) and ACLED low-activity (1) have NULL rc_likelihood → 8 assessed
+    assert rc["total_assessed"] == 8
+    assert rc["levels"]["L0"] == 5
     assert rc["levels"]["L1"] == 2  # AAA/DR, BBB/ACE
     assert rc["levels"]["L2"] == 1  # AAA/ACE
     assert rc["levels"]["L3"] == 0
 
-    # L1+ rate = 3/9
-    assert abs(rc["l1_plus_rate"] - 3 / 9) < 0.01
+    # L1+ rate = 3/8
+    assert abs(rc["l1_plus_rate"] - 3 / 8) < 0.01
 
     # By hazard
     by_haz = {h["hazard_code"]: h for h in rc["by_hazard"]}
@@ -292,9 +297,10 @@ def test_run_summary_rc_assessment(api_env: None) -> None:
     assert by_haz["ACE"]["L1"] == 1
     assert by_haz["DR"]["L1"] == 1
 
-    # Countries by level: L1 = AAA + BBB (2), L2 = AAA (1)
-    assert rc["countries_by_level"]["L1"] >= 2
-    assert rc["countries_by_level"]["L2"] >= 1
+    # Countries by level (max level per country):
+    # AAA: max = L2, BBB: max = L1, CCC: max = L0
+    assert rc["countries_by_level"]["L1"] == 1  # BBB (max L1)
+    assert rc["countries_by_level"]["L2"] == 1  # AAA (max L2)
 
 
 def test_run_summary_tracks(api_env: None) -> None:

--- a/web/src/components/RiskIndexPanel.tsx
+++ b/web/src/components/RiskIndexPanel.tsx
@@ -387,7 +387,12 @@ export default function RiskIndexPanel({
               onChange={handleRunChange}
             />
           </div>
-          {!isSummaryView && (
+          {isSummaryView ? (
+            <div className="text-xs text-fred-muted">
+              Select a non-summary metric view to see the forecast index map and
+              country-level results.
+            </div>
+          ) : (
             <div className="space-y-1 text-xs text-fred-muted">
               <div>
                 World overview • Jenks breaks calculated from the selected risk values.

--- a/web/src/components/RunSelector.tsx
+++ b/web/src/components/RunSelector.tsx
@@ -31,7 +31,7 @@ const RunSelector = ({
   selectedRunId,
   onChange,
 }: RunSelectorProps) => {
-  if (!availableRuns || availableRuns.length <= 1) return null;
+  if (!availableRuns || availableRuns.length === 0) return null;
 
   return (
     <label className="flex items-center gap-2 text-sm text-fred-text">

--- a/web/src/components/RunSummaryView.tsx
+++ b/web/src/components/RunSummaryView.tsx
@@ -72,7 +72,12 @@ function KpiRow({ data }: Props) {
         }
       />
       <KpiCard
-        label="Ensemble models"
+        label={
+          <span className="inline-flex items-center gap-1">
+            Ensemble models
+            <InfoTooltip text="Distinct LLM models that produced forecasts for Track 1 (full ensemble) questions. Expected count is from the ensemble configuration." />
+          </span>
+        }
         value={`${data.ensemble.ok} / ${data.ensemble.expected}`}
       />
       <KpiCard
@@ -106,8 +111,8 @@ function CoverageFunnel({ data }: Props) {
   const c = data.coverage;
   const steps = [
     { label: "countries scanned", value: c.countries_scanned, color: "bg-fred-primary" },
-    { label: "hazard pairs assessed", value: c.hazard_pairs_assessed, color: "bg-fred-primary/80" },
-    { label: "pairs with questions", value: c.pairs_with_questions, color: "bg-fred-primary/60" },
+    { label: "country/hazard pairs assessed", value: c.hazard_pairs_assessed, color: "bg-fred-primary/80" },
+    { label: "country/hazard pairs with questions", value: c.pairs_with_questions, color: "bg-fred-primary/60" },
     { label: "forecast questions", value: c.total_questions, color: "bg-fred-primary/40" },
   ];
   const maxVal = Math.max(...steps.map((s) => s.value), 1);
@@ -129,14 +134,26 @@ function CoverageFunnel({ data }: Props) {
           </div>
         ))}
       </div>
-      <p className="mt-3 text-xs text-fred-muted">
-        {c.seasonal_screenouts.toLocaleString()} seasonal screen-outs
-        {" · "}
-        {c.triaged_quiet.toLocaleString()} triaged quiet
-        {" · "}
-        {c.countries_no_questions.toLocaleString()} countries with no questions
-        generated
-      </p>
+      <div className="mt-3 space-y-1.5 text-xs text-fred-muted">
+        <p>
+          {c.seasonal_screenouts.toLocaleString()} country/hazard pairs seasonally screened out
+          {" · "}
+          {c.acled_low_activity.toLocaleString()} country/hazard pairs with quiet conflict (ACLED low activity)
+          {" · "}
+          {c.triaged_quiet.toLocaleString()} country/hazard pairs triaged quiet
+          {" · "}
+          {c.countries_no_questions.toLocaleString()} countries with no questions generated
+        </p>
+        <p>
+          Each country/hazard pair can produce multiple forecast questions because
+          different metrics apply to each hazard type. For example, an Armed
+          Conflict (ACE) pair generates both a Fatalities and a People Affected
+          question. Flood and Tropical Cyclone pairs each produce a People
+          Affected question and an Event Occurrence question. Drought pairs
+          produce a Phase 3+ Population question (for FEWS NET countries) or an
+          Event Occurrence question.
+        </p>
+      </div>
     </Section>
   );
 }
@@ -260,18 +277,26 @@ function RcAssessment({ data }: Props) {
 
   return (
     <Section title="Regime change assessment">
+      <p className="mb-3 text-xs text-fred-muted">
+        Regime Change (RC) measures how much a country/hazard pair is expected to
+        deviate from its historical base rate. Each pair is scored on likelihood
+        and magnitude to produce an RC level. L1+ pairs are promoted to Track 1
+        (full LLM ensemble forecast); L0 pairs go to Track 2 (single model
+        forecast). Higher RC levels indicate greater expected deviation from
+        normal conditions.
+      </p>
       <RcBar levels={rc.levels} />
       <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-fred-muted">
         {(["L0", "L1", "L2", "L3"] as const).map((key) => (
           <span key={key} className="inline-flex items-center gap-1">
             <span className={`inline-block h-2.5 w-2.5 rounded-sm ${RC_COLORS[key].bg}`} />
-            {key} {RC_LEVEL_LABELS[key]} ({rc.levels[key]})
+            {key} {RC_LEVEL_LABELS[key]} ({rc.levels[key]} pairs)
             {key !== "L0" && rc.countries_by_level[key] > 0 && (
               <span className="text-fred-muted">
                 · {rc.countries_by_level[key]}{" "}
                 <span className="inline-flex items-center gap-0.5">
                   countries
-                  <InfoTooltip text="Countries with at least one hazard flagged at this level (a country may appear at multiple levels)." />
+                  <InfoTooltip text={`Countries whose highest RC level across all hazards is ${key}.`} />
                 </span>
               </span>
             )}
@@ -279,7 +304,7 @@ function RcAssessment({ data }: Props) {
         ))}
       </div>
       <p className="mt-2 text-xs text-fred-muted">
-        {rc.total_assessed.toLocaleString()} hazard-country pairs assessed
+        {rc.total_assessed.toLocaleString()} country/hazard pairs assessed
         {" · "}
         {l1Plus} RC-promoted to Track 1
         {" · "}
@@ -299,7 +324,7 @@ function TrackSplit({ data }: Props) {
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         <div className="rounded-lg border border-fred-primary/30 bg-fred-primary/5 p-4">
           <div className="text-xs font-semibold uppercase tracking-wide text-fred-primary">
-            Track 1 — full ensemble
+            Track 1 — full ensemble forecast
           </div>
           <div className="mt-1 text-2xl font-bold text-fred-primary">
             {t.track1.questions} questions
@@ -310,7 +335,7 @@ function TrackSplit({ data }: Props) {
         </div>
         <div className="rounded-lg border border-fred-secondary/30 bg-fred-secondary/5 p-4">
           <div className="text-xs font-semibold uppercase tracking-wide text-fred-secondary">
-            Track 2 — single model
+            Track 2 — single model forecast
           </div>
           <div className="mt-1 text-2xl font-bold text-fred-secondary">
             {t.track2.questions} questions

--- a/web/src/components/__tests__/RunSummaryView.test.tsx
+++ b/web/src/components/__tests__/RunSummaryView.test.tsx
@@ -36,6 +36,7 @@ const MOCK_DATA: RunSummaryResponse = {
     countries_scanned: 122,
     hazard_pairs_assessed: 365,
     seasonal_screenouts: 123,
+    acled_low_activity: 15,
     pairs_with_questions: 120,
     total_questions: 229,
     countries_with_forecasts: 73,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -136,6 +136,7 @@ export type RunSummaryResponse = {
     countries_scanned: number;
     hazard_pairs_assessed: number;
     seasonal_screenouts: number;
+    acled_low_activity: number;
     pairs_with_questions: number;
     total_questions: number;
     countries_with_forecasts: number;


### PR DESCRIPTION
## Summary

- **Seasonal screen-outs**: Fixed detection to use `data_quality_json` status field instead of NULL `regime_change_likelihood` (which is always set since RC runs before triage). Was showing 0 screen-outs.
- **ACLED low-activity**: Added quiet conflict count to coverage funnel.
- **LLM errors**: Fixed counting all calls as errors — empty-string `error_text` (`'' IS NOT NULL` = true) was matching everything. Now requires non-empty string.
- **RC country counts**: Changed from `>= level` to `MAX level = level` per country, fixing "45 countries for 35 L1 pairs" display.
- **Ensemble models**: Filtered to Track 1 models only (excluded `ensemble_*` and `track2_*` names). Added tooltip explaining the metric.
- **Labels**: Renamed phase labels (HS triage → Horizon Scan Triage and RC, SPD ensemble → Ensemble Forecasts), track labels (added "forecast"), coverage funnel (hazard pairs → country/hazard pairs).
- **Selectors**: RunSelector now visible with 1 run; added helper text for summary view.
- **Explanatory text**: Added RC explanation paragraph and coverage funnel paragraph explaining how pairs produce multiple questions.

## Test plan

- [x] All 9 backend tests pass (coverage, RC, tracks, cost, LLM health, PA/FATALITIES KPI regression)
- [x] Next.js build succeeds
- [ ] Verify on production: seasonal screen-outs > 0, LLM errors < 100%, RC country counts ≤ pair counts, ensemble models ≤ 7

https://claude.ai/code/session_015YjuRFNnarBR5AD81B6uQz