### PR TITLE
feat: rename to Run Results, redesign sidebar, add performance, fix map

### DIFF
--- a/pythia/api/app.py
+++ b/pythia/api/app.py
@@ -4034,7 +4034,7 @@ def diagnostics_run_summary(
                 ) or 0
 
     # ---- Ensemble health --------------------------------------------------
-    ensemble: Dict[str, int] = {"expected": 7, "ok": tracks["track1"]["models"]}
+    ensemble: Dict[str, int] = {"expected": 6, "ok": tracks["track1"]["models"]}
 
     # ---- Cost breakdown ---------------------------------------------------
     cost: Dict[str, Any] = {
@@ -4127,6 +4127,37 @@ def diagnostics_run_summary(
                     llm_health["errors"] / llm_health["total_calls"], 3
                 )
 
+    # ---- Performance scores -------------------------------------------------
+    performance: Dict[str, Any] = {
+        "resolved_questions": 0,
+        "total_questions": coverage.get("total_questions", 0),
+        "brier": {"avg": None, "median": None},
+        "log": {"avg": None, "median": None},
+        "crps": {"avg": None, "median": None},
+    }
+    if _table_exists(con, "resolutions") and q_filter:
+        performance["resolved_questions"] = _q1(
+            f"SELECT COUNT(DISTINCT r.question_id) FROM resolutions r "
+            f"JOIN questions q ON r.question_id = q.question_id "
+            f"WHERE {q_filter}{tf_q}",
+            q_params,
+        ) or 0
+
+    if _table_exists(con, "scores") and q_filter:
+        for score_type in ["brier", "log", "crps"]:
+            row = _q(
+                f"SELECT AVG(s.value), MEDIAN(s.value) FROM scores s "
+                f"JOIN questions q ON s.question_id = q.question_id "
+                f"WHERE {q_filter}{tf_q} AND s.score_type = ? "
+                f"AND s.model_name LIKE 'ensemble_%'",
+                q_params + [score_type],
+            )
+            if row and row[0][0] is not None:
+                performance[score_type] = {
+                    "avg": round(float(row[0][0]), 4),
+                    "median": round(float(row[0][1]), 4) if row[0][1] is not None else None,
+                }
+
     return {
         "run_id": run_id,
         "hs_run_id": hs_run_id,
@@ -4137,6 +4168,7 @@ def diagnostics_run_summary(
         "tracks": tracks,
         "ensemble": ensemble,
         "cost": cost,
+        "performance": performance,
         "llm_health": llm_health,
     }
 

--- a/tests/test_api_run_summary.py
+++ b/tests/test_api_run_summary.py
@@ -234,6 +234,8 @@ def test_run_summary_shape(api_env: None) -> None:
     assert "ensemble" in data
     assert "cost" in data
     assert "llm_health" in data
+    assert "performance" in data
+    assert data["ensemble"]["expected"] == 6  # DeepSeek removed
 
 
 def test_run_summary_coverage(api_env: None) -> None:

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -70,7 +70,7 @@ export default async function OverviewPage({
     <div className="space-y-6">
       <section className="space-y-2">
         <h1 className="text-3xl font-semibold">
-          Humanitarian Impact Forecast Index
+          Run Results
         </h1>
         <p className="text-sm text-fred-text">
           Last updated:{" "}

--- a/web/src/components/Nav.tsx
+++ b/web/src/components/Nav.tsx
@@ -48,7 +48,7 @@ const Nav = () => {
               className="text-fred-primary font-semibold hover:text-fred-secondary"
               href="/"
             >
-              Forecast Index
+              Run Results
             </Link>
             <Link
               className="text-fred-primary font-semibold hover:text-fred-secondary"
@@ -159,7 +159,7 @@ const Nav = () => {
                 className="text-fred-primary font-semibold hover:text-fred-secondary"
                 href="/"
               >
-                Forecast Index
+                Run Results
               </Link>
               <Link
                 className="text-fred-primary font-semibold hover:text-fred-secondary"

--- a/web/src/components/RiskIndexMap.tsx
+++ b/web/src/components/RiskIndexMap.tsx
@@ -429,6 +429,14 @@ export default function RiskIndexMap({
           2: "#fb923c",
           3: "#ef4444",
         };
+        // Centroid overrides for countries whose SVG bounding-box center
+        // is misleading (multi-part geometry spanning dateline, overseas
+        // territories, etc.). Coordinates are in the SVG viewBox (0-1000 x 0-500).
+        const centroidOverrides: Record<string, { cx: number; cy: number }> = {
+          RUS: { cx: 560, cy: 115 },  // European Russia (not Siberian center)
+          USA: { cx: 150, cy: 175 },  // CONUS (not mid-Pacific with Alaska/Hawaii)
+          FRA: { cx: 468, cy: 162 },  // Metropolitan France (not mid-Atlantic with overseas)
+        };
         rcByIso3.forEach((level, iso3) => {
           const elements = iso3ElementMap.get(iso3) ?? [];
           if (!elements.length) {
@@ -474,13 +482,25 @@ export default function RiskIndexMap({
           if (!Number.isFinite(width) || !Number.isFinite(height)) {
             return;
           }
-          const radius = Math.max(2, Math.min(8, Math.min(width, height) * 0.2));
+          // Scale radius by EIV when available; fall back to country bbox size
+          const countryRow = riskRows.find(
+            (r) => r.iso3?.toUpperCase() === iso3.toUpperCase()
+          );
+          const eiv = countryRow?.expected_value ?? countryRow?.total ?? null;
+          let radius: number;
+          if (eiv != null && Number.isFinite(eiv) && eiv > 0) {
+            // Log-scale EIV into 3-10 range
+            radius = Math.max(3, Math.min(10, 2 + Math.log10(eiv + 1) * 1.5));
+          } else {
+            radius = Math.max(2, Math.min(8, Math.min(width, height) * 0.2));
+          }
           const circle = document.createElementNS(
             "http://www.w3.org/2000/svg",
             "circle"
           );
-          circle.setAttribute("cx", String(minX + width / 2));
-          circle.setAttribute("cy", String(minY + height / 2));
+          const override = centroidOverrides[iso3.toUpperCase()];
+          circle.setAttribute("cx", String(override ? override.cx : minX + width / 2));
+          circle.setAttribute("cy", String(override ? override.cy : minY + height / 2));
           circle.setAttribute("r", String(radius));
           circle.setAttribute("fill", rcColors[level] ?? rcColors[1]);
           circle.setAttribute("stroke", "rgba(15, 23, 42, 0.75)");
@@ -988,8 +1008,8 @@ export default function RiskIndexMap({
                 { label: "Very low", color: "var(--risk-map-c1)" },
               ]
           ).concat([
-            { label: "In country list but not forecasted", color: "var(--risk-map-no-eiv)" },
-            { label: "Not in country list", color: "var(--risk-map-no-questions)" },
+            { label: "Scanned, no forecasts", color: "var(--risk-map-no-eiv)" },
+            { label: "Not scanned", color: "var(--risk-map-no-questions)" },
           ]).map((item) => (
             <div key={item.label} className="flex items-center gap-2">
               <span
@@ -1013,6 +1033,7 @@ export default function RiskIndexMap({
               <span>{item.label}</span>
             </div>
           ))}
+          <div className="mt-0.5 text-[10px] text-fred-muted">Circle size indicates EIV</div>
         </div>
       </div>
       {debugEnabled && debugInfo ? (

--- a/web/src/components/RiskIndexPanel.tsx
+++ b/web/src/components/RiskIndexPanel.tsx
@@ -8,12 +8,11 @@ import type {
   CountriesResponse,
   CountriesRow,
   DiagnosticsKpiScopesResponse,
+  PerformanceScoresResponse,
   RiskIndexResponse,
   RiskView,
   RunSummaryResponse,
 } from "../lib/types";
-import InfoTooltip from "./InfoTooltip";
-import KpiCard from "./KpiCard";
 import RiskIndexMap from "./RiskIndexMap";
 import RiskIndexTable from "./RiskIndexTable";
 import RunMonthSelector from "./RunMonthSelector";
@@ -115,9 +114,6 @@ const HAZARD_LABELS: Record<string, string> = {
   WH: "Wildfire",
 };
 
-const RC_LEVEL_TOOLTIP =
-  "RC means Regime Change, and refers to a score 0-1 that reflects Fred's expectation of a significant change from the base rate";
-
 export default function RiskIndexPanel({
   initialResponse,
   countriesRows,
@@ -143,6 +139,7 @@ export default function RiskIndexPanel({
   );
   const [summaryData, setSummaryData] = useState<RunSummaryResponse | null>(null);
   const [summaryLoading, setSummaryLoading] = useState(false);
+  const [perfScores, setPerfScores] = useState<PerformanceScoresResponse | null>(null);
   const searchParams = useSearchParams();
   const showKpiDebug = searchParams?.get("debug_kpi") === "1";
 
@@ -177,6 +174,19 @@ export default function RiskIndexPanel({
     view === "FATALITIES_PC" ||
     view === "PHASE3PLUS_PC" ||
     view === "EVENT_OCCURRENCE";
+
+  const fetchPerfScores = async (metricScope: string) => {
+    try {
+      const resp = await apiGet<PerformanceScoresResponse>(
+        "/performance/scores",
+        { metric: metricScope, include_test: includeTest || undefined }
+      );
+      setPerfScores(resp);
+    } catch {
+      console.warn("Performance scores unavailable");
+      setPerfScores(null);
+    }
+  };
 
   const fetchCountries = async (
     metricScope: string,
@@ -269,6 +279,7 @@ export default function RiskIndexPanel({
         const nextMetricScope = metricScopeForView(nextView);
         void fetchKpiScopes(nextMetricScope, selectedRunMonth, selectedRunId);
         void fetchCountries(nextMetricScope, selectedRunMonth, selectedRunId);
+        void fetchPerfScores(nextMetricScope);
       }
     } catch (fetchError) {
       console.warn("Risk index unavailable:", fetchError);
@@ -440,110 +451,142 @@ export default function RiskIndexPanel({
                 view={view}
               />
             </div>
-            <div className="space-y-4" data-testid="risk-index-kpi-panel">
-              <div className="rounded-lg border border-fred-secondary bg-fred-surface p-4 shadow-fredCard">
-                <div className="flex items-center justify-between gap-3">
-                  <div className="text-xs uppercase tracking-wide text-fred-muted">
-                    {selectedRunMonth
-                      ? `Selected run ${selectedRunMonth}`
-                      : "Selected run"}
-                  </div>
+            <div className="space-y-3" data-testid="risk-index-kpi-panel">
+              {/* Coverage */}
+              <div className="rounded-lg border border-fred-secondary bg-fred-surface p-3 shadow-fredCard">
+                <div className="text-[11px] uppercase tracking-wide text-fred-muted">
+                  Coverage
                 </div>
                 {kpiError ? (
-                  <div className="mt-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+                  <div className="mt-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-[11px] text-amber-200">
                     {kpiError}
                   </div>
                 ) : null}
-                <div className="mt-3 grid grid-cols-2 gap-3">
-                  <KpiCard
-                    label="Forecasts"
-                    value={selectedScope?.forecasts ?? 0}
-                  />
-                  <KpiCard
-                    label="Countries with Forecasts"
-                    value={
-                      selectedScope?.countries_with_forecasts ??
-                      selectedScope?.countries ??
-                      0
-                    }
-                  />
-                </div>
-                <div className="mt-3 grid grid-cols-2 gap-3">
+                <div className="mt-2 grid grid-cols-2 gap-2 text-sm">
                   <div>
-                    <KpiCard
-                      label="Countries Triaged"
-                      value={selectedScope?.countries_triaged ?? 0}
-                    />
-                    {showKpiDebug ? (
-                      <div className="mt-1 text-[11px] text-fred-muted">
-                        countries_triaged_source:{" "}
-                        {String(
-                          kpiData.diagnostics?.countries_triaged_source ?? "unknown"
-                        )}
-                      </div>
-                    ) : null}
+                    <div className="text-[11px] text-fred-muted">Forecasts</div>
+                    <div className="text-lg font-semibold text-fred-primary">{selectedScope?.forecasts ?? 0}</div>
                   </div>
-                  <KpiCard
-                    label="Resolved Forecasts"
-                    value={selectedScope?.resolved_questions ?? 0}
-                  />
+                  <div>
+                    <div className="text-[11px] text-fred-muted">Countries</div>
+                    <div className="text-lg font-semibold text-fred-primary">
+                      {selectedScope?.countries_with_forecasts ?? selectedScope?.countries ?? 0}
+                      <span className="ml-1 text-xs font-normal text-fred-muted">
+                        / {selectedScope?.countries_triaged ?? 0} triaged
+                      </span>
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-[11px] text-fred-muted">Resolved</div>
+                    <div className="text-lg font-semibold text-fred-primary">{selectedScope?.resolved_questions ?? 0}</div>
+                  </div>
+                  <div>
+                    <div className="text-[11px] text-fred-muted">By hazard</div>
+                    <div className="mt-0.5 flex flex-wrap gap-1">
+                      {hazardEntries.length ? (
+                        hazardEntries.map(([code, count]) => (
+                          <span key={code} className="inline-block rounded-full bg-fred-primary/10 px-1.5 py-0.5 text-[11px] font-medium text-fred-primary">
+                            {code} {count}
+                          </span>
+                        ))
+                      ) : (
+                        <span className="text-[11px] text-fred-muted">—</span>
+                      )}
+                    </div>
+                  </div>
                 </div>
-                <div className="mt-3 grid grid-cols-3 gap-3">
-                  <KpiCard
-                    label={
-                      <span className="inline-flex items-center gap-1">
-                        RC L1 countries <InfoTooltip text={RC_LEVEL_TOOLTIP} />
-                      </span>
-                    }
-                    value={rcLevelCounts.level1}
-                  />
-                  <KpiCard
-                    label={
-                      <span className="inline-flex items-center gap-1">
-                        RC L2 countries <InfoTooltip text={RC_LEVEL_TOOLTIP} />
-                      </span>
-                    }
-                    value={rcLevelCounts.level2}
-                  />
-                  <KpiCard
-                    label={
-                      <span className="inline-flex items-center gap-1">
-                        RC L3 countries <InfoTooltip text={RC_LEVEL_TOOLTIP} />
-                      </span>
-                    }
-                    value={rcLevelCounts.level3}
-                  />
+              </div>
+
+              {/* RC Assessment */}
+              <div className="rounded-lg border border-fred-secondary bg-fred-surface p-3 shadow-fredCard">
+                <div className="text-[11px] uppercase tracking-wide text-fred-muted">
+                  Regime Change
                 </div>
-                <p className="mt-3 text-xs text-fred-muted">
-                  {kpiData.explanations?.[0] ??
-                    "RC L1, L2, and L3 questions are forecasted with the full Fred LLM ensemble. All others, which are expected to stay close to base rates, are forecasted with a single LLM."}
+                <div className="mt-2 flex h-5 w-full overflow-hidden rounded">
+                  {([
+                    { key: "level0" as const, color: "bg-teal-600", count: countries.length - rcLevelCounts.level1 - rcLevelCounts.level2 - rcLevelCounts.level3 },
+                    { key: "level1" as const, color: "bg-amber-500", count: rcLevelCounts.level1 },
+                    { key: "level2" as const, color: "bg-orange-500", count: rcLevelCounts.level2 },
+                    { key: "level3" as const, color: "bg-red-600", count: rcLevelCounts.level3 },
+                  ] as const).map(({ key, color, count }) => {
+                    const total = countries.length || 1;
+                    const pct = (count / total) * 100;
+                    if (count === 0) return null;
+                    return (
+                      <div
+                        key={key}
+                        className={`${color} flex items-center justify-center text-[10px] font-semibold text-white`}
+                        style={{ width: `${pct}%`, minWidth: count > 0 ? "18px" : 0 }}
+                      >
+                        {pct > 8 ? count : ""}
+                      </div>
+                    );
+                  })}
+                </div>
+                <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-fred-muted">
+                  <span><span className="inline-block h-2 w-2 rounded-sm bg-teal-600" /> L0</span>
+                  <span><span className="inline-block h-2 w-2 rounded-sm bg-amber-500" /> L1 ({rcLevelCounts.level1})</span>
+                  <span><span className="inline-block h-2 w-2 rounded-sm bg-orange-500" /> L2 ({rcLevelCounts.level2})</span>
+                  <span><span className="inline-block h-2 w-2 rounded-sm bg-red-600" /> L3 ({rcLevelCounts.level3})</span>
+                </div>
+                <p className="mt-1.5 text-[11px] text-fred-muted">
+                  L1+ countries forecast with full ensemble; L0 with single model.
                 </p>
-                <div className="mt-4">
-                  <div className="text-xs uppercase tracking-wide text-fred-muted">
-                    Forecasts by hazard type
-                  </div>
-                  <div className="mt-3 grid grid-cols-2 gap-3">
-                    {hazardEntries.length ? (
-                      hazardEntries.map(([code, count]) => (
-                        <div
-                          key={code}
-                          className="rounded-lg border border-fred-secondary/70 bg-fred-surface px-3 py-2 text-sm"
-                        >
-                          <div className="text-xs text-fred-muted">
-                            {(HAZARD_LABELS[code] ?? "Hazard") + ` (${code})`}
-                          </div>
-                          <div className="mt-1 text-lg font-semibold text-fred-primary">
-                            {count}
-                          </div>
-                        </div>
-                      ))
-                    ) : (
-                      <div className="text-xs text-fred-muted">
-                        No hazard forecasts in this scope.
-                      </div>
-                    )}
-                  </div>
+              </div>
+
+              {/* Performance */}
+              <div className="rounded-lg border border-fred-secondary bg-fred-surface p-3 shadow-fredCard">
+                <div className="text-[11px] uppercase tracking-wide text-fred-muted">
+                  Performance
                 </div>
+                {(() => {
+                  const rows = perfScores?.summary_rows ?? [];
+                  const ensembleRows = rows.filter(
+                    (r) => r.model_name != null && r.model_name.startsWith("ensemble_")
+                  );
+                  const brierRow = ensembleRows.find((r) => r.score_type === "brier");
+                  const logRow = ensembleRows.find((r) => r.score_type === "log");
+                  const crpsRow = ensembleRows.find((r) => r.score_type === "crps");
+                  const fmt = (v: number | null | undefined) =>
+                    v != null ? v.toFixed(3) : "—";
+                  return (
+                    <div className="mt-2 grid grid-cols-2 gap-2 text-sm">
+                      <div>
+                        <div className="text-[11px] text-fred-muted">Resolved</div>
+                        <div className="text-lg font-semibold text-fred-primary">
+                          {selectedScope?.resolved_questions ?? 0}
+                        </div>
+                      </div>
+                      <div>
+                        <div className="text-[11px] text-fred-muted">Brier</div>
+                        <div className="text-lg font-semibold text-fred-primary">
+                          {fmt(brierRow?.avg_value)}
+                        </div>
+                        <div className="text-[10px] text-fred-muted">
+                          med {fmt(brierRow?.median_value)}
+                        </div>
+                      </div>
+                      <div>
+                        <div className="text-[11px] text-fred-muted">Log Loss</div>
+                        <div className="text-lg font-semibold text-fred-primary">
+                          {fmt(logRow?.avg_value)}
+                        </div>
+                        <div className="text-[10px] text-fred-muted">
+                          med {fmt(logRow?.median_value)}
+                        </div>
+                      </div>
+                      <div>
+                        <div className="text-[11px] text-fred-muted">CRPS</div>
+                        <div className="text-lg font-semibold text-fred-primary">
+                          {fmt(crpsRow?.avg_value)}
+                        </div>
+                        <div className="text-[10px] text-fred-muted">
+                          med {fmt(crpsRow?.median_value)}
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })()}
               </div>
             </div>
           </div>

--- a/web/src/components/RunSummaryView.tsx
+++ b/web/src/components/RunSummaryView.tsx
@@ -349,7 +349,52 @@ function TrackSplit({ data }: Props) {
   );
 }
 
-// ---- 6. Cost breakdown ----
+// ---- 6. Performance ----
+function PerformanceSection({ data }: Props) {
+  const p = data.performance;
+  const fmtScore = (v: number | null) => (v != null ? v.toFixed(3) : "—");
+
+  return (
+    <Section title="Performance">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <div className="rounded-lg border border-fred-secondary/70 bg-fred-bg p-3">
+          <div className="text-xs uppercase tracking-wide text-fred-muted">
+            Forecasts resolved
+          </div>
+          <div className="mt-1 text-xl font-bold text-fred-primary">
+            {p.resolved_questions}
+            <span className="ml-1 text-sm font-normal text-fred-muted">
+              / {p.total_questions}
+            </span>
+          </div>
+        </div>
+        {(["brier", "log", "crps"] as const).map((key) => {
+          const label =
+            key === "brier" ? "Brier" : key === "log" ? "Log Loss" : "CRPS";
+          const score = p[key];
+          return (
+            <div
+              key={key}
+              className="rounded-lg border border-fred-secondary/70 bg-fred-bg p-3"
+            >
+              <div className="text-xs uppercase tracking-wide text-fred-muted">
+                {label}
+              </div>
+              <div className="mt-1 text-xl font-bold text-fred-primary">
+                {fmtScore(score.avg)}
+              </div>
+              <div className="text-[11px] text-fred-muted">
+                median {fmtScore(score.median)}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Section>
+  );
+}
+
+// ---- 7. Cost breakdown ----
 function CostBreakdown({ data }: Props) {
   return (
     <Section title="Cost breakdown">
@@ -381,6 +426,7 @@ export default function RunSummaryView({ data }: Props) {
       <MetricGrid data={data} />
       <RcAssessment data={data} />
       <TrackSplit data={data} />
+      <PerformanceSection data={data} />
       <CostBreakdown data={data} />
     </div>
   );

--- a/web/src/components/__tests__/RunSummaryView.test.tsx
+++ b/web/src/components/__tests__/RunSummaryView.test.tsx
@@ -113,6 +113,13 @@ const MOCK_DATA: RunSummaryResponse = {
     errors: 10,
     error_rate: 0.003,
   },
+  performance: {
+    resolved_questions: 120,
+    total_questions: 229,
+    brier: { avg: 0.245, median: 0.198 },
+    log: { avg: 1.32, median: 1.05 },
+    crps: { avg: 0.156, median: 0.128 },
+  },
 };
 
 describe("RunSummaryView", () => {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -166,6 +166,13 @@ export type RunSummaryResponse = {
     errors: number;
     error_rate: number;
   };
+  performance: {
+    resolved_questions: number;
+    total_questions: number;
+    brier: { avg: number | null; median: number | null };
+    log: { avg: number | null; median: number | null };
+    crps: { avg: number | null; median: number | null };
+  };
 };
 
 export type QuestionsResponse = {


### PR DESCRIPTION
## Summary

- **Page rename**: "Humanitarian Impact Forecast Index" → "Run Results", nav link updated
- **DeepSeek removed**: Expected ensemble count 7 → 6
- **Map fixes**: Russia RC circle centroid override (was positioned off in Siberia), EIV-based RC circle sizing (log-scale), legend text updates ("Scanned, no forecasts" / "Not scanned" / "Circle size indicates EIV")
- **Sidebar redesign** (non-summary metric views): Replaced old KPI cards + RC boxes + hazard grid with 3 compact sections: Coverage (forecasts/countries/resolved/hazard pills), Regime Change (proportional bar), Performance (Brier/Log Loss/CRPS avg+median from `/performance/scores`)
- **Summary view**: Added Performance section (Resolved, Brier, Log Loss, CRPS)
- **API**: Added `performance` field to `/v1/diagnostics/run_summary`

## Test plan

- [x] 9 backend tests pass (including ensemble expected=6 check)
- [x] Next.js build succeeds
- [ ] Verify page title shows "Run Results"
- [ ] Verify Russia RC circle centered on European Russia
- [ ] Verify sidebar shows Coverage/RC/Performance sections
- [ ] Verify summary view shows Performance section

https://claude.ai/code/session_015YjuRFNnarBR5AD81B6uQz