### PR TITLE
fix: recover from WAL replay InternalException on API startup

### DIFF
--- a/pythia/api/app.py
+++ b/pythia/api/app.py
@@ -255,16 +255,24 @@ _SYNC_CHECK_INTERVAL_S = 60  # how often to poll for DB refresh
 def _open_duckdb_connection() -> duckdb.DuckDBPyConnection:
     """Open a fresh DuckDB connection to the configured DB path.
 
-    If the WAL file is stale (e.g. contains a duplicate ALTER TABLE ADD COLUMN
-    from a previous ``ensure_schema`` run), delete it and retry.  The WAL is a
-    replay log of uncommitted changes; removing it loses at most the last
-    incomplete transaction, which is acceptable for a read-heavy API server
-    whose authoritative data comes from the synced DB file.
+    If the WAL file is stale, delete it and retry.  Observed failure modes:
+
+    * ``CatalogException``: WAL contains a duplicate ALTER TABLE ADD COLUMN
+      from a previous ``ensure_schema`` run.
+    * ``InternalException``: WAL replay fails with ``Calling
+      DatabaseManager::GetDefaultDatabase with no default database set``,
+      typically when the WAL was produced by a different DuckDB process/build
+      (e.g. downloaded alongside an artifact) and the main database has not
+      yet been attached at replay time.
+
+    The WAL is a replay log of uncommitted changes; removing it loses at most
+    the last incomplete transaction, which is acceptable for a read-heavy API
+    server whose authoritative data comes from the synced DB file.
     """
     db_url = load_cfg()["app"]["db_url"].replace("duckdb:///", "")
     try:
         con = duckdb.connect(db_url, read_only=False)
-    except duckdb.CatalogException as exc:
+    except (duckdb.CatalogException, duckdb.InternalException) as exc:
         wal_path = Path(db_url + ".wal")
         if wal_path.exists():
             logger.warning(

--- a/pythia/api/db_sync.py
+++ b/pythia/api/db_sync.py
@@ -146,6 +146,20 @@ def download_db_atomic(dest_path: Path) -> None:
 
     os.replace(tmp_path, dest_path)
 
+    # Any WAL file present now belongs to the previous DB instance (which we
+    # just replaced) or to the process that produced the downloaded artifact.
+    # Replaying it against the new DB file risks an InternalException
+    # ("Calling DatabaseManager::GetDefaultDatabase with no default database
+    # set").  The fresh DB file is the authoritative snapshot, so the stale
+    # WAL is expendable.
+    wal_path = dest_path.with_suffix(dest_path.suffix + ".wal")
+    try:
+        if wal_path.exists():
+            wal_path.unlink()
+            logger.info("Removed stale WAL alongside refreshed DB: %s", wal_path)
+    except OSError as exc:
+        logger.warning("Failed to remove stale WAL %s: %s", wal_path, exc)
+
 
 def db_was_refreshed() -> bool:
     """Check and clear the DB-refreshed flag.


### PR DESCRIPTION
## Summary
- Production API was returning 500 on `/v1/diagnostics/kpi_scopes` (and every other DB-backed endpoint) because DuckDB crashed on WAL replay with `_duckdb.InternalException: Calling DatabaseManager::GetDefaultDatabase with no default database set`.
- The existing recovery path in `_open_duckdb_connection` only handled `CatalogException`, so this different replay failure propagated up and the singleton read connection was never established.

## Changes
- Catch `InternalException` alongside `CatalogException` in `pythia/api/app.py::_open_duckdb_connection` and delete the stale WAL before retrying (the fresh DB file is authoritative, so the WAL is expendable).
- After `download_db_atomic` replaces the DB file, proactively remove any adjacent `.wal` file in `pythia/api/db_sync.py`. Any WAL present at that moment belongs to the now-replaced DB (or the artifact producer) and is stale by definition.

## Test plan
- [ ] CI (`web-ci`, `resolver-ci-fast`, `resolver-smoke`, `lint`, `ci-lint`, `forecaster-ci`) is green.
- [ ] Render deploys the fix and `/v1/diagnostics/kpi_scopes?metric_scope=PA` returns 200 (observed 500 before this PR).
- [ ] Subsequent syncs that re-download the DB artifact no longer leave a stale `.wal` behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)