### PR TITLE
feat: add GDELT Conflict Events to Resolver page (Other Alerts)

### DIFF
--- a/pythia/api/app.py
+++ b/pythia/api/app.py
@@ -4597,6 +4597,12 @@ _SOURCE_REGISTRY: dict[str, dict] = {
                          "columns": ["iso3", "risk_title", "risk_level",
                                      "risk_type", "risk_trend"],
                          "order": "fetched_at DESC"},
+    "gdelt":            {"table": "gdelt_conflict_indicators",
+                         "columns": ["iso3", "event_date", "total_events",
+                                     "tier1_events", "tier2_events",
+                                     "tier3_events", "avg_goldstein",
+                                     "avg_tone_conflict"],
+                         "order": "event_date DESC"},
     # --- Other ---
     "acaps_inform":     {"table": "acaps_inform_severity",
                          "columns": ["iso3", "crisis_name", "severity_score",
@@ -4619,6 +4625,7 @@ _SOURCE_LABELS: dict[str, str] = {
     "reliefweb": "ReliefWeb", "acaps_daily": "ACAPS Daily Monitoring",
     "acled_political": "ACLED Political Events",
     "hdx_signals": "HDX Signals", "acaps_risk_radar": "ACAPS Risk Radar",
+    "gdelt": "GDELT Conflict Events",
     "acaps_inform": "ACAPS INFORM Severity",
     "acaps_access": "ACAPS Humanitarian Access",
     "ipc_api": "IPC API",
@@ -4635,6 +4642,7 @@ _SOURCE_CATEGORIES: dict[str, str] = {
     "reliefweb": "situation_reports", "acaps_daily": "situation_reports",
     "acled_political": "situation_reports",
     "hdx_signals": "other_alerts", "acaps_risk_radar": "other_alerts",
+    "gdelt": "other_alerts",
     "acaps_inform": "other", "acaps_access": "other",
     "ipc_api": "resolution_data",
 }

--- a/web/src/app/resolver/ResolverClient.tsx
+++ b/web/src/app/resolver/ResolverClient.tsx
@@ -71,7 +71,7 @@ const CATEGORIES = [
   {
     key: "other_alerts",
     title: "Other Alerts",
-    sources: ["hdx_signals", "acaps_risk_radar"],
+    sources: ["hdx_signals", "acaps_risk_radar", "gdelt"],
   },
   {
     key: "other",


### PR DESCRIPTION
## Summary

Adds GDELT to the Resolver page's accordion data explorer under the \"Other Alerts\" category. Exposes the \`gdelt_conflict_indicators\` table with 8 curated columns: \`iso3\`, \`event_date\`, \`total_events\`, \`tier1_events\`, \`tier2_events\`, \`tier3_events\`, \`avg_goldstein\`, \`avg_tone_conflict\`.

Verified locally: Resolver page renders the new row with \`last_updated=2026-04-17\` and \`global_rows=17,704\`, expanded accordion loads 500 rows across the curated columns.

## ReliefWeb + ACLED CAST findings (reported separately; not fixed in this PR)

- **ReliefWeb** is stuck on \`2026-03-26\` because \`api.reliefweb.int/v1\` returns HTTP 410 Gone: *\"The API version 'v1' has been decommissioned. Please use version 'v2' instead.\"* v2 refuses the current \`appname\` (\`UNICEF-Resolver-P1L1T6\`) with HTTP 403 — ReliefWeb requires an approved appname. Requires upstream work: register a new appname with ReliefWeb and migrate \`_bulk_fetch_reliefweb\` in \`pythia/tools/ingest_structured_data.py\` to v2.
- **ACLED CAST** shows \`2026-04-12\` because today's Resolver Update call returned 0 records (API succeeded with empty body). The existing rows are from the 2026-04-12 \`ingest-structured-data.yml\` weekly refresh. ACLED CAST publishes new forecasts on a cadence — the date is not stale per se, it's the latest vintage available from the upstream service.

## Test plan

- [ ] CI + Lint pass.
- [ ] After Render redeploys, Resolver page shows a third row under Other Alerts: \"GDELT Conflict Events\" with \`last_updated=2026-04-17\` and \`global_rows=17,704\`.
- [ ] Expanding the GDELT row loads a table of recent events (iso3, event_date, CAMEO tier counts, Goldstein/tone averages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)