### PR TITLE
fix: migrate ReliefWeb connector from decommissioned v1 API to v2

### DIFF
--- a/horizon_scanner/reliefweb.py
+++ b/horizon_scanner/reliefweb.py
@@ -35,7 +35,7 @@ _STALENESS_DAYS = 60  # days_back (45) + 15-day grace
 _DEFAULT_DAYS_BACK = 45
 _DEFAULT_MAX_REPORTS = 15
 _BODY_EXCERPT_LENGTH = 500
-_API_BASE_URL = "https://api.reliefweb.int/v1"
+_API_BASE_URL = "https://api.reliefweb.int/v2"
 _MAX_PROMPT_REPORTS = 10
 
 

--- a/pythia/tools/ingest_structured_data.py
+++ b/pythia/tools/ingest_structured_data.py
@@ -812,7 +812,7 @@ def _bulk_fetch_reliefweb(
             "offset": offset,
         }
 
-        url = "https://api.reliefweb.int/v1/reports"
+        url = "https://api.reliefweb.int/v2/reports"
         headers = {"Accept": "application/json"}
         params = {"appname": appname}
 


### PR DESCRIPTION
## Summary

The ReliefWeb \`/v1/reports\` endpoint now returns HTTP 410 Gone: *\"The API version 'v1' has been decommissioned. Please use version 'v2' instead.\"* This broke both the bulk ingest (\`_bulk_fetch_reliefweb\` in \`pythia/tools/ingest_structured_data.py\`) and the Horizon Scanner per-country fetch path (\`horizon_scanner/reliefweb.py\`).

The existing \`UNICEF-Resolver-P1L1T6\` appname is already approved for v2, and the POST payload + response JSON shape are identical between v1 and v2, so this is a pure URL bump — no other code changes needed.

## Verification

Live-tested v2 with the full POST payload the ingest path sends. Got 531 reports in the last 3 days with the expected \`fields.title\`, \`fields.date.created\`, \`fields.primary_country.iso3\`, \`fields.source\` shape that the existing parsers consume.

## Test plan

- [ ] CI + Lint pass.
- [ ] Next Resolver Update run writes new rows to \`reliefweb_reports\` with \`fetched_at\` = today.
- [ ] Resolver page row for ReliefWeb shows a current \`last_updated\` (green) instead of 2026-03-26 (yellow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)