### PR TITLE
feat(performance): empty-state tile for "questions too new to resolve"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,7 +229,7 @@ Forecasts cover a 6-month window. Each question has `window_start_date` and `tar
 **API endpoints (Phase 4):**
 - `/v1/risk_index?metric=EVENT_OCCURRENCE` — Returns binary P(event) as the risk value (0-1). No centroid multiplication. Per-capita returns raw probability unchanged (already a rate).
 - `/v1/risk_index?metric=PHASE3PLUS_IN_NEED` — SPD-based risk index for IPC Phase 3+ population. Supports `normalize=true` for per-capita (fraction of population in Phase 3+).
-- `/v1/diagnostics/resolution_rates` — Returns resolution rates by (hazard_code, metric): total/resolved/skipped questions with rate. Supports `hazard_code` filter.
+- `/v1/diagnostics/resolution_rates` — Returns resolution rates by (hazard_code, metric): total/resolved/skipped/pending_too_new questions with rate. Supports `hazard_code` filter. `pending_too_new` is the count of questions whose `window_start_date` is after the resolution pipeline's calendar cutoff (previous complete month) — i.e. structurally unresolvable until the calendar advances. The Performance page's Resolution Coverage Summary renders a muted "Awaiting first horizon — questions too new, will resolve next month" tile (instead of red 0%) when `pending_too_new == total_questions`, so brand-new epoch questions don't look like calibration failures.
 - `/v1/diagnostics/kpi_scopes?metric_scope=EVENT_OCCURRENCE` — KPI scopes now accept EVENT_OCCURRENCE and PHASE3PLUS_IN_NEED alongside PA and FATALITIES.
 - `/v1/performance/scores?metric=EVENT_OCCURRENCE` — Performance scores work for all metrics; binary questions produce Brier score only (no log/CRPS).
 

--- a/pythia/api/app.py
+++ b/pythia/api/app.py
@@ -3099,6 +3099,13 @@ def resolution_rates(
     # These were the bulk of the dashboard's permanent-0% tiles.
     retired_filter = "AND COALESCE(q.status, '') != 'retired'"
 
+    # The resolution pipeline's calendar cutoff is the previous complete
+    # month (see pythia/tools/compute_resolutions.py). A question's earliest
+    # horizon maps to its window_start_date month. So a question is
+    # "pending_too_new" — structurally unresolvable until the calendar
+    # advances — when window_start_date > the first day of the cutoff month.
+    has_window_start = _table_has_columns(con, "questions", ["window_start_date"])
+
     # Total questions by (hazard_code, metric)
     _tf = _test_filter(include_test, "r")
     total_sql = f"""
@@ -3113,6 +3120,27 @@ def resolution_rates(
     except Exception:
         return {"rows": []}
 
+    pending_map: dict[tuple[str, str], int] = {}
+    if has_window_start:
+        # window_start_date is stored as TEXT in some DBs and DATE in others.
+        # DATE_TRUNC works on both via DuckDB's TRY_CAST behaviour.
+        pending_sql = f"""
+            SELECT q.hazard_code, UPPER(q.metric) AS metric,
+                   COUNT(DISTINCT q.question_id) AS pending
+            FROM questions q
+            WHERE 1=1 {hazard_filter} {run_filter} {retired_filter}{_test_filter(include_test, "q")}
+              AND CAST(q.window_start_date AS DATE)
+                  > DATE_TRUNC('month', CURRENT_DATE - INTERVAL 1 MONTH)
+            GROUP BY q.hazard_code, UPPER(q.metric)
+        """
+        try:
+            for hc, m, n in _execute(con, pending_sql, params).fetchall():
+                pending_map[(hc, m)] = int(n)
+        except Exception:
+            # If the date cast fails or column is unusable, fall through with
+            # an empty pending_map — the response still includes 0 pending.
+            pending_map = {}
+
     if not has_resolutions:
         return {
             "rows": [
@@ -3122,6 +3150,7 @@ def resolution_rates(
                     "total_questions": int(t),
                     "resolved_questions": 0,
                     "skipped_questions": int(t),
+                    "pending_too_new": pending_map.get((hc, m), 0),
                     "resolution_rate": 0.0,
                 }
                 for hc, m, t in total_rows
@@ -3158,6 +3187,7 @@ def resolution_rates(
             "total_questions": total_int,
             "resolved_questions": resolved,
             "skipped_questions": skipped,
+            "pending_too_new": pending_map.get((hc, m), 0),
             "resolution_rate": round(rate, 4),
         })
 

--- a/tests/test_api_resolution_rates_pending.py
+++ b/tests/test_api_resolution_rates_pending.py
@@ -1,0 +1,142 @@
+# Pythia
+# Copyright (c) 2025 Kevin Wyjad
+# Licensed under the Pythia Non-Commercial Public License v1.0.
+# See the LICENSE file in the project root for details.
+
+"""`/v1/diagnostics/resolution_rates` must return a `pending_too_new` count
+per (hazard, metric) group so the dashboard can distinguish "all questions
+from the latest epoch, haven't had a chance to resolve yet" from real 0%
+calibration failures."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from typing import Generator
+
+import pytest
+import yaml
+
+duckdb = pytest.importorskip("duckdb")
+fastapi_testclient = pytest.importorskip("fastapi.testclient")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from pythia import config as pythia_config  # noqa: E402
+from pythia.api import app as _app_mod  # noqa: E402
+from pythia.api.app import app  # noqa: E402
+
+
+def _write_config(tmp_path: Path, db_path: Path) -> Path:
+    cfg = {"app": {"db_url": f"duckdb:///{db_path}"}}
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    return path
+
+
+@pytest.fixture()
+def api_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[Path, None, None]:
+    """A DB with three groups:
+
+      - ACE/FATALITIES: 2 questions from a past epoch (1 resolved, 1 unresolved)
+      - FL/PA: 2 questions ENTIRELY from the current month (all pending_too_new)
+      - TC/PA: 1 past + 1 future (partially pending — must not flip to "all pending")
+    """
+    db_path = tmp_path / "api.duckdb"
+    con = duckdb.connect(str(db_path), read_only=False)
+    con.execute(
+        """
+        CREATE TABLE questions (
+            question_id TEXT,
+            hazard_code TEXT,
+            metric TEXT,
+            status TEXT,
+            window_start_date DATE,
+            is_test BOOLEAN DEFAULT FALSE
+        );
+        """
+    )
+    con.execute(
+        """
+        CREATE TABLE resolutions (
+            question_id TEXT,
+            horizon_m INTEGER,
+            value DOUBLE,
+            is_test BOOLEAN DEFAULT FALSE
+        );
+        """
+    )
+
+    today = date.today()
+    # "Past" = first day of the month two months ago — guaranteed to be on or
+    # before the calendar cutoff (previous complete month).
+    if today.month <= 2:
+        past = date(today.year - 1, today.month + 10, 1)
+    else:
+        past = date(today.year, today.month - 2, 1)
+    # "Future" = first day of next month — guaranteed to be after the cutoff.
+    if today.month == 12:
+        future = date(today.year + 1, 1, 1)
+    else:
+        future = date(today.year, today.month + 1, 1)
+
+    con.executemany(
+        """
+        INSERT INTO questions(question_id, hazard_code, metric, status, window_start_date)
+        VALUES (?,?,?,?,?)
+        """,
+        [
+            ("ace_past_a", "ACE", "FATALITIES", "active", past),
+            ("ace_past_b", "ACE", "FATALITIES", "active", past),
+            ("fl_future_a", "FL", "PA", "active", future),
+            ("fl_future_b", "FL", "PA", "active", future),
+            ("tc_past", "TC", "PA", "active", past),
+            ("tc_future", "TC", "PA", "active", future),
+        ],
+    )
+    con.execute(
+        "INSERT INTO resolutions(question_id, horizon_m, value) VALUES ('ace_past_a', 1, 3.0)"
+    )
+    con.close()
+
+    config_path = _write_config(tmp_path, db_path)
+    monkeypatch.setenv("PYTHIA_CONFIG_PATH", str(config_path))
+    pythia_config.load.cache_clear()
+    _app_mod._READ_CON = None
+    _app_mod._READ_CON_MTIME = None
+
+    try:
+        yield db_path
+    finally:
+        pythia_config.load.cache_clear()
+        _app_mod._READ_CON = None
+        _app_mod._READ_CON_MTIME = None
+
+
+def test_pending_too_new_counts(api_env: Path) -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/diagnostics/resolution_rates")
+    assert resp.status_code == 200, resp.text
+    rows = resp.json()["rows"]
+    by_key = {(r["hazard_code"], r["metric"]): r for r in rows}
+
+    # ACE/FATALITIES — both questions are from a past epoch. None pending.
+    ace = by_key[("ACE", "FATALITIES")]
+    assert ace["total_questions"] == 2
+    assert ace["pending_too_new"] == 0
+    assert ace["resolved_questions"] == 1
+
+    # FL/PA — both questions are from the future epoch. Group is fully pending,
+    # which is the empty-state condition the dashboard renders specially.
+    fl = by_key[("FL", "PA")]
+    assert fl["total_questions"] == 2
+    assert fl["pending_too_new"] == 2
+    assert fl["resolved_questions"] == 0
+
+    # TC/PA — mixed. Pending count is 1 (not equal to total), so the dashboard
+    # will NOT flip this tile into empty-state — it's a genuine low-resolution
+    # case worth surfacing.
+    tc = by_key[("TC", "PA")]
+    assert tc["total_questions"] == 2
+    assert tc["pending_too_new"] == 1
+    assert tc["resolved_questions"] == 0

--- a/web/src/app/performance/PerformancePanel.tsx
+++ b/web/src/app/performance/PerformancePanel.tsx
@@ -704,8 +704,17 @@ export default function PerformancePanel({
           <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
             {resolutionRates.map((row) => {
               const pct = (row.resolution_rate * 100).toFixed(1);
-              const colorClass =
-                row.resolution_rate >= 0.9
+              const pending = row.pending_too_new ?? 0;
+              // Empty-state: every question in this (hazard, metric) group is
+              // from an epoch whose earliest horizon hasn't reached the
+              // calendar cutoff yet. Show "pending" copy instead of a red 0%.
+              const isAllPending =
+                row.total_questions > 0 &&
+                row.resolved_questions === 0 &&
+                pending === row.total_questions;
+              const colorClass = isAllPending
+                ? "text-fred-muted"
+                : row.resolution_rate >= 0.9
                   ? "text-green-500"
                   : row.resolution_rate >= 0.5
                     ? "text-yellow-500"
@@ -720,15 +729,29 @@ export default function PerformancePanel({
                 <div
                   key={`${row.hazard_code}-${row.metric}`}
                   className="rounded border border-fred-secondary bg-fred-surface px-3 py-2"
+                  title={
+                    isAllPending
+                      ? `${row.total_questions} questions in this group are from the latest forecast epoch — their earliest horizon hasn't reached the resolution calendar cutoff yet.`
+                      : undefined
+                  }
                 >
                   <div className="text-[11px] font-semibold uppercase tracking-wide text-fred-muted">
                     {row.hazard_code} / {metricLabel}
                   </div>
                   <div className={`mt-1 text-sm font-medium ${colorClass}`}>
-                    {pct}% scored
+                    {isAllPending ? "Awaiting first horizon" : `${pct}% scored`}
                   </div>
                   <div className="text-xs text-fred-muted">
-                    {row.resolved_questions}/{row.total_questions} questions
+                    {isAllPending ? (
+                      <>
+                        0 / {row.total_questions} — questions too new, will
+                        resolve next month
+                      </>
+                    ) : (
+                      <>
+                        {row.resolved_questions}/{row.total_questions} questions
+                      </>
+                    )}
                   </div>
                 </div>
               );

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -236,6 +236,15 @@ export type ResolutionRateRow = {
   total_questions: number;
   resolved_questions: number;
   skipped_questions: number;
+  /**
+   * Questions whose earliest horizon (window_start_date) is after the
+   * resolution pipeline's calendar cutoff (previous complete month). These
+   * are structurally unresolvable until the calendar advances — typically
+   * brand-new questions from the latest epoch. The dashboard uses this to
+   * distinguish a "waiting for first horizon" state from a real 0% scored.
+   * Optional for backward compatibility with older API versions.
+   */
+  pending_too_new?: number;
   resolution_rate: number;
 };
 


### PR DESCRIPTION
## Summary

The Resolution Coverage Summary on /performance renders red 0% tiles for any (hazard, metric) group that has no resolutions — including groups where every question is from the latest forecast epoch and structurally cannot have resolved yet (e.g. today, all four `DR/PHASE3PLUS_IN_NEED`, `*_EVENT_OCCURRENCE` groups, where every question has `window_start_date=2026-05-01` and the calendar cutoff is still 2026-04). That tile state looks like a calibration failure but is just "we asked the question last week, give it a month".

This PR distinguishes the two by adding a `pending_too_new` count to the API and a muted "Awaiting first horizon — questions too new, will resolve next month" empty-state tile on the dashboard.

## Changes

- **`pythia/api/app.py`** — `/v1/diagnostics/resolution_rates` returns a new `pending_too_new` count per row: the count of questions whose `window_start_date` is after the resolution pipeline's calendar cutoff (previous complete month), mirroring the logic in `pythia/tools/compute_resolutions.py`. Guarded behind a column-presence check so older DBs without `window_start_date` fall through with 0 pending.
- **`web/src/lib/types.ts`** — new optional `pending_too_new` field on `ResolutionRateRow`.
- **`web/src/app/performance/PerformancePanel.tsx`** — tiles flip into a muted "Awaiting first horizon — 0 / N — questions too new, will resolve next month" empty-state when `total > 0 && resolved == 0 && pending == total`. Mixed-pending and resolved groups render unchanged. Tooltip on the tile explains why.
- **`tests/test_api_resolution_rates_pending.py`** (new) — fixture covers all past (ACE/FATALITIES, 0 pending), all future (FL/PA, fully pending → empty-state condition), and mixed (TC/PA, partial pending → regular display).
- **`CLAUDE.md`** — documents the new field and tile state.

## Verification

### Backend tests
```
$ pytest pythia/tests/ tests/test_api_diagnostics_schema_tolerant.py tests/test_api_diagnostics_retired_questions.py tests/test_api_resolution_rates_pending.py
177 passed
```

### Frontend
- `npx next lint` — no new warnings, no errors.
- `npx tsc --noEmit` — clean.

### Browser preview
Ran `npm run dev` pointing at the production API (`https://pythia-vdu3.onrender.com/v1`), monkey-patched fetch to inject `pending_too_new == total_questions` for the four currently-pending groups (FL/DR/TC EVENT_OCCURRENCE + DR/PHASE3PLUS_IN_NEED). Captured DOM after the patched state was set:

```
Resolution Coverage Summary
DR / PA              → 0.0% scored   0/70 questions          (red — partial pending kept old display)
FL / PA              → 4.0% scored   7/177 questions         (red — partial pending kept old display)
DI / PA              → 0.0% scored   0/97 questions          (red — retired-but-not-yet-cleaned)
HW / PA              → 0.0% scored   0/41 questions          (red — same)
FL / BINARY (EVENT)  → Awaiting first horizon  0 / 73 — questions too new, will resolve next month   ✓ NEW
DR / BINARY (EVENT)  → Awaiting first horizon  0 / 63 — questions too new, will resolve next month   ✓ NEW
ACE / PA             → 1.7% scored   3/180 questions         (red — partial pending kept old display)
TC / PA              → 4.2% scored   2/48 questions          (red — partial pending kept old display)
ACE / FATALITIES     → 48.9% scored  88/180 questions        (green — resolved, kept old display)
DR / PHASE 3+        → Awaiting first horizon  0 / 42 — questions too new, will resolve next month   ✓ NEW
TC / BINARY (EVENT)  → Awaiting first horizon  0 / 12 — questions too new, will resolve next month   ✓ NEW
```

Color confirmed via `preview_inspect`:
- Empty-state copy uses `text-fred-muted` → `rgb(107, 114, 128)` (gray).
- Red 0% tiles use `text-red-500` → `rgb(239, 68, 68)`.

Tooltip on each empty-state tile reads: "N questions in this group are from the latest forecast epoch — their earliest horizon hasn't reached the resolution calendar cutoff yet."

## Production effect after merge

API and dashboard immediately stop showing red 0% for the four "all-new-epoch" groups. By June (when the calendar cutoff advances past May 2026), those questions become resolvable; the EMA scoring chain fills `resolutions` / `scores`, and the dashboard re-renders the tiles with real numbers. DI/PA and HW/PA tiles will disappear separately after the previous PR (#764) runs its `retire_blocked_hazard_questions` step on the next Compute Calibration cycle.

## Test plan

- [x] Backend tests pass locally (177 tests)
- [x] Frontend lint + tsc pass
- [x] Browser preview confirms new tile renders with correct copy, muted color, and tooltip
- [ ] CI: lint, YAML Lint, web-ci, forecaster-spd-tests
- [ ] Post-merge: check `curl https://pythia-vdu3.onrender.com/v1/diagnostics/resolution_rates | jq '.rows[0]'` shows `pending_too_new` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)