### PR TITLE
web tests: fix 5 pre-existing RunSummaryView/RiskIndexPanel failures

### DIFF
--- a/web/src/components/__tests__/RiskIndexPanel.test.tsx
+++ b/web/src/components/__tests__/RiskIndexPanel.test.tsx
@@ -72,14 +72,16 @@ describe("RiskIndexPanel", () => {
 
     await waitFor(() => expect(apiGetMock).toHaveBeenCalled());
 
+    // Per-capita views are first-class options in VIEW_OPTIONS and are never
+    // disabled — switching to a fatalities view must not remove or disable them.
     expect(
       screen.getByRole("option", {
-        name: "People Affected (PA) per capita EIV",
+        name: "People affected (per capita)",
       })
     ).not.toBeDisabled();
     expect(
       screen.getByRole("option", {
-        name: "Armed Conflict (ACE) fatalities per capita EIV",
+        name: "Fatalities (per capita)",
       })
     ).not.toBeDisabled();
   });

--- a/web/src/components/__tests__/RunSummaryView.test.tsx
+++ b/web/src/components/__tests__/RunSummaryView.test.tsx
@@ -168,19 +168,25 @@ describe("RunSummaryView", () => {
   it("shows metric question counts", () => {
     render(<RunSummaryView data={MOCK_DATA} />);
 
-    // The metric grid should show correct question counts
-    expect(screen.getByText("47")).toBeDefined(); // Fatalities
-    expect(screen.getByText("89")).toBeDefined(); // PA
-    expect(screen.getByText("73")).toBeDefined(); // EVENT_OCCURRENCE
-    expect(screen.getByText("20")).toBeDefined(); // PHASE3PLUS_IN_NEED
+    // The metric grid should show each question count. Some counts (47, 20, 73)
+    // legitimately appear more than once in the rendered summary (e.g. 73 is
+    // both the EVENT_OCCURRENCE question count and the coverage funnel's
+    // countries-with-forecasts), so assert presence via getAllByText.
+    expect(screen.getAllByText("47").length).toBeGreaterThan(0); // Fatalities
+    expect(screen.getAllByText("89").length).toBeGreaterThan(0); // PA
+    expect(screen.getAllByText("73").length).toBeGreaterThan(0); // EVENT_OCCURRENCE
+    expect(screen.getAllByText("20").length).toBeGreaterThan(0); // PHASE3PLUS_IN_NEED
   });
 
   it("shows hazard pills", () => {
     render(<RunSummaryView data={MOCK_DATA} />);
 
-    // Should show hazard pills like "Armed Conflict (47)"
-    expect(screen.getByText("Armed Conflict (47)")).toBeDefined();
-    expect(screen.getByText("Flood (36)")).toBeDefined();
+    // Hazard pills like "Armed Conflict (47)". A hazard can contribute to more
+    // than one metric (ACE has 47 both as Fatalities and as People affected;
+    // FL has 36 under both PA and Event occurrence), so the pill legitimately
+    // renders in multiple metric cards — assert via getAllByText.
+    expect(screen.getAllByText("Armed Conflict (47)").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Flood (36)").length).toBeGreaterThan(0);
   });
 
   it("shows cost per phase", () => {

--- a/web/src/setupTests.ts
+++ b/web/src/setupTests.ts
@@ -1,1 +1,12 @@
 import "@testing-library/jest-dom/vitest";
+
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+// Unmount rendered components after each test. testing-library only
+// auto-registers this when `afterEach` is a global (vitest `globals: true`),
+// which this project does not enable — without it, each render() stacks in
+// document.body and `getByText` finds duplicate matches across tests.
+afterEach(() => {
+  cleanup();
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  // Use the automatic JSX runtime (react/jsx-runtime), matching how Next builds
+  // the app (tsconfig "jsx": "preserve"). Without this, esbuild defaults to the
+  // classic transform (React.createElement), which throws "React is not defined"
+  // when rendering components that don't import React — the app relies on the
+  // automatic runtime, so components intentionally don't.
+  esbuild: { jsx: "automatic" },
   test: {
     environment: "jsdom",
     setupFiles: "./src/setupTests.ts",


### PR DESCRIPTION
## Summary

`npm test` (vitest) currently fails 5 tests in `web/` — 4 in `RunSummaryView.test.tsx`, 1 in `RiskIndexPanel.test.tsx`. These pre-date this change (they fail on `main`) and went unnoticed because **`web-ci.yml` runs only lint + build, not vitest**. This PR fixes all 5; the suite is now 10/10 green.

There were **three independent root causes**:

1. **`React is not defined` on render.** Vitest's esbuild defaulted to the *classic* JSX transform (`React.createElement`), but the app's components rely on the *automatic* runtime (matching Next's `tsconfig` `"jsx": "preserve"`) and don't import React. Fixed by setting `esbuild: { jsx: "automatic" }` in `vitest.config.ts` — one line, no new dependency, matches how the app is actually built.

2. **DOM stacked across tests.** `@testing-library/react` only auto-registers `afterEach(cleanup)` when `afterEach` is a global (vitest `globals: true`), which this project doesn't enable — so each `render()` accumulated in `document.body` and `getByText` found duplicate matches across tests. Fixed by registering `cleanup` explicitly in `src/setupTests.ts`.

3. **Stale assertions.** `RunSummaryView` used `getByText` on values that legitimately repeat within one render (a hazard contributes to multiple metrics; `73` is both a metric count and the coverage-funnel's countries-with-forecasts) → switched to `getAllByText`. `RiskIndexPanel` asserted option labels that no longer exist after the `VIEW_OPTIONS` refactor (per-capita is now a first-class, never-disabled view option) → updated to the current labels.

## Changed files

- `web/vitest.config.ts` — automatic JSX runtime
- `web/src/setupTests.ts` — explicit `afterEach(cleanup)`
- `web/src/components/__tests__/RunSummaryView.test.tsx` — `getAllByText` for repeated values
- `web/src/components/__tests__/RiskIndexPanel.test.tsx` — current option labels

## Verification

- `cd web && npm test` → **10 passed** (was 5 failed / 5 passed)
- `npm run lint` and `npm run build` remain clean

## Note

`web-ci.yml` does not run vitest today, so these failures weren't gated. Consider adding a `vitest run` step to the web CI so the suite is enforced going forward — happy to do that in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxspdzLMyMP276bh1zJmoR

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxspdzLMyMP276bh1zJmoR)_