### PR TITLE
diagnostics: make the is_test finding diagnosable from the job log

### DIFF
--- a/scripts/ci/stage_health.py
+++ b/scripts/ci/stage_health.py
@@ -283,12 +283,19 @@ def _markdown(rep: Dict[str, Any]) -> str:
     if g.get("available"):
         L.append("**Grounding**")
         L.append("")
-        L.append("| pass | calls | no-backend | % |")
-        L.append("|---|--:|--:|--:|")
-        for k in ("rc", "triage"):
-            s = g.get(k) or {}
-            if s.get("n_calls"):
+        rows = [(k, g.get(k) or {}) for k in ("rc", "triage")]
+        rows = [(k, s) for k, s in rows if s.get("n_calls")]
+        if rows:
+            L.append("| pass | calls | no-backend | % |")
+            L.append("|---|--:|--:|--:|")
+            for k, s in rows:
                 L.append(f"| {k} | {s['n_calls']} | {s['n_no_backend']} | {s['no_backend_pct']}% |")
+        else:
+            # An empty table is ambiguous between "grounding failed entirely"
+            # and "grounding happened in an earlier stage". Say which.
+            scope = "this stage's window" if rep.get("since") else "this run"
+            L.append(f"_No grounding calls in {scope} — grounding runs in the hs_submit "
+                     f"and hs_rc_collect stages._")
         L.append("")
         for k in ("rc", "triage"):
             for mid, v in ((g.get(k) or {}).get("no_backend_by_reason") or {}).items():
@@ -308,6 +315,17 @@ def _markdown(rep: Dict[str, Any]) -> str:
         exp = it.get("matches_expected")
         extra = "" if exp is None else (" · matches expected" if exp else " · **does NOT match expected**")
         L.append(f"**is_test**: {status} — values {it['distinct_values']}{extra}")
+        # Always render the per-table counts, not just on failure. When this
+        # first fired in production the summary said "INCONSISTENT" but the
+        # breakdown was only in the JSON artifact — and artifacts are exactly
+        # what a restricted-network reader cannot fetch, so the finding was
+        # visible but undiagnosable.
+        L.append("")
+        L.append("| table | " + " | ".join(sorted({k for c in it["per_table"].values() for k in c})) + " |")
+        keys = sorted({k for c in it["per_table"].values() for k in c})
+        L.append("|---|" + "--:|" * len(keys))
+        for table, counts in sorted(it["per_table"].items()):
+            L.append(f"| {table} | " + " | ".join(str(counts.get(k, 0)) for k in keys) + " |")
         L.append("")
 
     c = rep.get("cost") or {}

--- a/scripts/ci/tests/test_stage_health.py
+++ b/scripts/ci/tests/test_stage_health.py
@@ -247,3 +247,33 @@ def test_writes_step_summary(tmp_path, monkeypatch):
     monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(s))
     _run(path, tmp_path)
     assert "Stage health" in s.read_text()
+
+
+def test_is_test_breakdown_is_rendered_in_markdown(tmp_path, monkeypatch):
+    """The per-table counts must reach the LOG, not only the JSON artifact.
+
+    When this check first fired in production it reported INCONSISTENT but the
+    breakdown lived only in the artifact — unreadable from a restricted-network
+    session, so the finding was visible and undiagnosable at the same time.
+    """
+    monkeypatch.delenv("PYTHIA_TEST_MODE", raising=False)
+    path = _db(tmp_path)
+    con = duckdb.connect(path)
+    _call(con, call_id="c1", is_test=True)
+    con.execute("INSERT INTO hs_triage VALUES (?, 1, 1, FALSE)", [RUN])
+    con.close()
+
+    rep = _run(path, tmp_path)
+    md = stage_health._markdown(rep)
+    assert "| llm_calls |" in md
+    assert "| hs_triage |" in md
+
+
+def test_absent_grounding_is_explained_not_blank(tmp_path):
+    """A bare empty table can't distinguish 'failed' from 'happens elsewhere'."""
+    path = _db(tmp_path)
+    con = duckdb.connect(path)
+    _call(con, call_id="c1", hazard_code="SPD_ACE")  # not a grounding row
+    con.close()
+    md = stage_health._markdown(_run(path, tmp_path))
+    assert "No grounding calls in" in md


### PR DESCRIPTION
## Why

The `stage_health` `is_test` check fired on its **first production run** — `hs_finalize_fc_submit`, pipeline `hs_20260729T071137`:

```
**is_test**: **INCONSISTENT** — values ['false', 'true'] · **does NOT match expected**
##[warning]expected True but stamped values are ['false', 'true']
```

`PYTHIA_TEST_MODE=1`, yet stamped tables for that run carry both values. The check worked. But the per-table breakdown went only to the JSON artifact — and artifacts are exactly what a restricted-network reader cannot fetch, so the finding was **visible and undiagnosable at the same time**. That's close to useless for the reader who most needs it.

## What

The markdown (which prints to stdout, and therefore into the job log) now always carries the per-table counts:

```
| table     | false | true |
|-----------|------:|-----:|
| hs_triage |     0 |    1 |
| llm_calls |     1 |    1 |
```

Rendered unconditionally rather than only on failure — it's three lines, and having the baseline visible on healthy runs makes an unhealthy one obvious.

Also fixes an ambiguity spotted in the same run: at a stage that does no grounding, the grounding table rendered as a bare header with no rows, which reads identically to "every grounding call failed". It now says so explicitly and names the stages where grounding actually runs.

## Tests

Two added (18 pass in the file): the per-table breakdown reaches the markdown, and absent grounding is explained rather than blank.

## Note

This does not fix the underlying `is_test` inconsistency — it makes it identifiable. Diagnosing the root cause needs the per-table detail this PR surfaces, which will appear in the `fc_collect_finalize` report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwQgijDpzSVopPHRCUudpK

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwQgijDpzSVopPHRCUudpK)_