### PR TITLE
fix: update the stale ACE/PA base-rate test that has been red on main

### DIFF
--- a/.github/workflows/forecaster-ci.yml
+++ b/.github/workflows/forecaster-ci.yml
@@ -25,6 +25,7 @@ on:
       - "pythia/llm_batch.py"
       - "pythia/model_costs.json"
       - "pythia/tests/**"
+      - "resolver/tests/test_idmc_history_conflict_pa.py"
       - "pythia/api/routes/costs.py"
       - "scripts/ci/poll_llm_batches.py"
       - "scripts/ci/check_pipeline_active.py"
@@ -200,9 +201,14 @@ jobs:
           # workflow — which is how ACE/PA sat on the legacy JSON-dump branch
           # with test_history_summary red on main and nobody seeing it.
           echo "=== Running base-rate history + rendering tests ==="
+          # test_idmc_history_conflict_pa lives under resolver/tests but covers
+          # forecaster's ACE/PA base rate. resolver-ci-fast does not trigger on
+          # forecaster/**, which is how it sat red on main after #816 re-routed
+          # ACE/PA without anything re-running it.
           pytest -vv \
             forecaster/tests/test_history_summary.py \
-            forecaster/tests/test_fewsnet_history.py
+            forecaster/tests/test_fewsnet_history.py \
+            resolver/tests/test_idmc_history_conflict_pa.py
 
       - name: Run SPD experimental mode (dual/bayesmc)
         if: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.spd_mode == 'bayesmc_write' || github.event.inputs.spd_mode == 'dual_compare_bayesmc_write') }}

--- a/resolver/tests/test_idmc_history_conflict_pa.py
+++ b/resolver/tests/test_idmc_history_conflict_pa.py
@@ -3,6 +3,18 @@
 # Licensed under the Pythia Non-Commercial Public License v1.0.
 # See the LICENSE file in the project root for details.
 
+"""ACE/PA base-rate contract.
+
+This test asserted the pre-#816 behaviour, where ACE/PA routed to
+_load_idmc_conflict_flow_history_summary and returned a flat dict keyed
+`source`/`history_length_months`. #816 deliberately re-routed ACE/PA to
+_build_conflict_base_rate so it renders a curated block instead of a raw JSON
+dump, which changed the shape to a `conflict_trajectory` carrying both series.
+The test kept asserting the old keys and has been failing on main ever since —
+invisibly, because it lives under resolver/tests while the code it covers is in
+forecaster/, and resolver-ci-fast does not trigger on forecaster/**.
+"""
+
 from __future__ import annotations
 
 import duckdb
@@ -11,9 +23,8 @@ import pytest
 from forecaster import cli as forecaster_cli  # type: ignore
 
 
-@pytest.mark.db
-def test_idmc_history_for_conflict_pa(monkeypatch, tmp_path):
-    db_path = tmp_path / "idmc_conflict_pa.duckdb"
+def _seed(db_path):
+    """facts_deltas with the columns the conflict builder actually selects."""
     con = duckdb.connect(str(db_path))
     try:
         con.execute(
@@ -24,31 +35,67 @@ def test_idmc_history_for_conflict_pa(monkeypatch, tmp_path):
                 hazard_code TEXT,
                 metric TEXT,
                 series_semantics TEXT,
-                value_new DOUBLE
+                value_new DOUBLE,
+                source_id TEXT
             )
             """
         )
         for month in range(1, 9):
-            ym = f"2024-{month:02d}-01"
             con.execute(
                 """
-                INSERT INTO facts_deltas (ym, iso3, hazard_code, metric, series_semantics, value_new)
-                VALUES (?, 'ETH', 'ACE', 'idp_displacement_flow_idmc', 'new', ?)
+                INSERT INTO facts_deltas
+                    (ym, iso3, hazard_code, metric, series_semantics, value_new, source_id)
+                VALUES (?, 'ETH', 'ACE', 'idp_displacement_flow_idmc', 'new', ?, 'idmc')
                 """,
-                [ym, 1000.0 * month],
+                [f"2024-{month:02d}-01", 1000.0 * month],
             )
+        con.execute(
+            """
+            CREATE TABLE acled_monthly_fatalities (
+                ym TEXT, iso3 TEXT, fatalities DOUBLE
+            )
+            """
+        )
     finally:
         con.close()
 
-    def fake_connect(read_only: bool = False):
-        return duckdb.connect(str(db_path))
 
-    monkeypatch.setattr(forecaster_cli, "connect", fake_connect)
+@pytest.mark.db
+def test_ace_pa_returns_a_conflict_trajectory(monkeypatch, tmp_path):
+    """ACE/PA must carry a `type`, or the prompt renderer falls back to a raw
+    JSON dump — the exact regression #816 fixed."""
+    db_path = tmp_path / "idmc_conflict_pa.duckdb"
+    _seed(db_path)
+    monkeypatch.setattr(forecaster_cli, "connect", lambda read_only=False: duckdb.connect(str(db_path)))
 
     summary = forecaster_cli._build_history_summary("ETH", "ACE", "PA")
-    assert summary["source"] == "IDMC"
-    assert summary["history_length_months"] == 8
-    assert summary["recent_max"] == pytest.approx(8000.0)
-    assert summary["recent_mean"] == pytest.approx(sum(range(3000, 9000, 1000)) / 6)
-    assert len(summary["last_6m_values"]) == 6
-    assert summary["last_6m_values"][-1]["value"] == pytest.approx(8000.0)
+
+    assert summary["type"] == "conflict_trajectory"
+    assert "displacements" in summary and "fatalities" in summary
+
+
+@pytest.mark.db
+def test_ace_pa_displacement_series_comes_from_idmc(monkeypatch, tmp_path):
+    """PA resolves against IDMC displacement, so that series must be populated."""
+    db_path = tmp_path / "idmc_conflict_pa.duckdb"
+    _seed(db_path)
+    monkeypatch.setattr(forecaster_cli, "connect", lambda read_only=False: duckdb.connect(str(db_path)))
+
+    disp = forecaster_cli._build_history_summary("ETH", "ACE", "PA")["displacements"]
+
+    assert disp["source"] == "IDMC"
+    assert disp["last_6m"], "IDMC displacement rows should have been picked up"
+    assert disp["last_6m"][-1]["value"] == pytest.approx(8000.0)
+
+
+@pytest.mark.db
+def test_ace_fatalities_shares_the_same_builder(monkeypatch, tmp_path):
+    """Both ACE metrics route through one trajectory builder (#816)."""
+    db_path = tmp_path / "idmc_conflict_pa.duckdb"
+    _seed(db_path)
+    monkeypatch.setattr(forecaster_cli, "connect", lambda read_only=False: duckdb.connect(str(db_path)))
+
+    assert (
+        forecaster_cli._build_history_summary("ETH", "ACE", "FATALITIES")["type"]
+        == "conflict_trajectory"
+    )


### PR DESCRIPTION
## `main` is currently red

`resolver/tests/test_idmc_history_conflict_pa.py::test_idmc_history_for_conflict_pa` fails with `KeyError: 'history_length_months'`. Reproduced on a clean `main` checkout — this is **not** caused by any open PR, and it currently blocks anything from merging green.

## Why

The test asserts the **pre-#816** contract: ACE/PA routes to `_load_idmc_conflict_flow_history_summary` and returns a flat dict keyed `source` / `history_length_months`.

#816 deliberately re-routed ACE/PA to `_build_conflict_base_rate` so it renders a curated block instead of a raw JSON dump — the code comment in `_build_history_summary` spells out exactly why. That changed the shape to a `conflict_trajectory` carrying both the IDMC displacement and ACLED fatalities series. The test was never updated.

## Why nobody saw it

The test lives under `resolver/tests/` but covers code in `forecaster/`, and `resolver-ci-fast` does **not** trigger on `forecaster/**`. So #816 changed the behaviour, ran the workflows its own paths triggered, and nothing re-ran this test.

This is the same directory/trigger mismatch CLAUDE.md already documents for the workflow lints — and, as it happens, the same class of gap fixed for the tail-packs writer test in #822. It now runs in `forecaster-ci` alongside the other base-rate suites, which is the workflow that actually fires when this code changes.

## What changed

Rewritten to the current contract rather than deleted — the behaviour is still worth pinning:

- ACE/PA returns a `conflict_trajectory` (a **missing `type` is precisely what sent it down the JSON-dump branch**, so this is the regression guard #816 wanted)
- the displacement series is sourced from IDMC and actually populated
- both ACE metrics share the one builder

The fixture also gains the `source_id` column the conflict builder selects — its absence was the secondary binder error behind the `KeyError`.

## Tests

3 pass locally. Wired into `forecaster-ci.yml` (file list + path trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwQgijDpzSVopPHRCUudpK

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwQgijDpzSVopPHRCUudpK)_