### PR TITLE
fix: stop counting unbatchable spend as a lost batch discount

### DIFF
--- a/scripts/ci/batch_economics.py
+++ b/scripts/ci/batch_economics.py
@@ -196,6 +196,40 @@ def _run_scope(hs_run_id: str, fc_run_id: str):
     return "(" + " OR ".join(clauses) + ")", params
 
 
+def _has_column(con, table: str, column: str) -> bool:
+    try:
+        rows = con.execute(f"PRAGMA table_info('{table}')").fetchall()
+        return any(str(r[1]) == column for r in rows)
+    except Exception:
+        return False
+
+
+def _batchable_sql(con) -> str:
+    """SQL predicate for llm_calls rows that a batch family could have carried.
+
+    Only four families are ever batched: spd_v2, binary_v2 (keyed by `phase`)
+    and hs_rc / hs_triage (the RC and triage model passes, identifiable only by
+    `call_type` — every HS row shares phase='hs_triage', grounding included).
+
+    Everything else has no batch family at all: grounding (rc_grounding /
+    triage_grounding), adversarial_search / adversarial_synthesis, scenario_v2
+    and sibyl. Counting those as "lost discount" — which a provider-level flag
+    does, because Gemini serves both batched RC passes and unbatchable grounding
+    — inflates the loss and makes the headline unactionable. On the 2026-07-30
+    SOM run it reported google losing 41.6% of batchable spend when none of that
+    spend was batchable in the first place.
+    """
+    phase_part = "phase IN ('spd_v2', 'binary_v2')"
+    if _has_column(con, "llm_calls", "call_type"):
+        return (
+            f"({phase_part} OR call_type LIKE 'rc_pass_%' "
+            "OR call_type LIKE 'triage_pass_%')"
+        )
+    # Pre-call_type DBs: phase alone cannot separate an RC pass from grounding,
+    # so count only the forecaster families rather than over-claim.
+    return f"({phase_part})"
+
+
 def _collect_cost_by_provider_tier(
     con,
     batches: List[Dict[str, Any]],
@@ -225,6 +259,7 @@ def _collect_cost_by_provider_tier(
             "reason": "no run id supplied; cost is only meaningful scoped to a run",
         }
 
+    batchable = _batchable_sql(con)
     rows = _rows(
         con,
         f"""
@@ -232,12 +267,13 @@ def _collect_cost_by_provider_tier(
             COALESCE(provider, '(none)'),
             CASE WHEN json_extract_string(usage_json, '$.service_tier') = 'batch'
                  THEN 'batch' ELSE 'full_price' END,
+            CASE WHEN {batchable} THEN 1 ELSE 0 END,
             COUNT(*),
             SUM(COALESCE(cost_usd, 0))
         FROM llm_calls
         WHERE {where}
-        GROUP BY 1, 2
-        ORDER BY 4 DESC
+        GROUP BY 1, 2, 3
+        ORDER BY 5 DESC
         """,
         params,
     )
@@ -250,7 +286,7 @@ def _collect_cost_by_provider_tier(
 
     by_provider: Dict[str, Dict[str, Any]] = {}
     run_total = 0.0
-    for provider, tier, n_calls, cost in rows:
+    for provider, tier, is_batchable, n_calls, cost in rows:
         cost = float(cost or 0.0)
         run_total += cost
         entry = by_provider.setdefault(
@@ -258,6 +294,7 @@ def _collect_cost_by_provider_tier(
             {
                 "batch_cost_usd": 0.0,
                 "full_price_cost_usd": 0.0,
+                "non_batchable_cost_usd": 0.0,
                 "n_batch_calls": 0,
                 "n_full_price_calls": 0,
                 "batch_attempted": str(provider).lower() in batched_providers,
@@ -266,21 +303,28 @@ def _collect_cost_by_provider_tier(
         if tier == "batch":
             entry["batch_cost_usd"] += cost
             entry["n_batch_calls"] += int(n_calls or 0)
-        else:
+        elif int(is_batchable or 0):
+            # Could have been batched and was not — this is the real loss.
             entry["full_price_cost_usd"] += cost
             entry["n_full_price_calls"] += int(n_calls or 0)
+        else:
+            # Grounding, adversarial, scenario, sibyl: no batch family exists,
+            # so this is expected full-price spend, not a lost discount.
+            entry["non_batchable_cost_usd"] += cost
 
     batched_spend = sum(e["batch_cost_usd"] for e in by_provider.values())
-    # Spend on providers we tried to batch, which nevertheless paid full price.
+    # Batchable spend on providers we actually created a batch for, which
+    # nevertheless paid full price.
     lost = sum(
         e["full_price_cost_usd"] for e in by_provider.values() if e["batch_attempted"]
     )
     batchable_spend = lost + sum(
         e["batch_cost_usd"] for e in by_provider.values() if e["batch_attempted"]
     )
+    non_batchable = sum(e["non_batchable_cost_usd"] for e in by_provider.values())
 
     for entry in by_provider.values():
-        for key in ("batch_cost_usd", "full_price_cost_usd"):
+        for key in ("batch_cost_usd", "full_price_cost_usd", "non_batchable_cost_usd"):
             entry[key] = round(entry[key], 4)
 
     return {
@@ -289,6 +333,7 @@ def _collect_cost_by_provider_tier(
         "run_total_cost_usd": round(run_total, 4),
         "batched_cost_usd": round(batched_spend, 4),
         "batchable_cost_usd": round(batchable_spend, 4),
+        "non_batchable_cost_usd": round(non_batchable, 4),
         "lost_discount_cost_usd": round(lost, 4),
         "lost_discount_pct_of_batchable": (
             round(100.0 * lost / batchable_spend, 1) if batchable_spend else 0.0
@@ -401,22 +446,32 @@ def _markdown(report: Dict[str, Any]) -> str:
                 f"(${cost['run_total_cost_usd']} total)."
             )
         lines.append("")
-        lines.append("| provider | batch attempted | batch $ | full-price $ | calls (batch/full) |")
-        lines.append("|---|---|--:|--:|---|")
+        lines.append(
+            "| provider | batch attempted | batch $ | lost $ | not batchable $ "
+            "| calls (batch/lost) |"
+        )
+        lines.append("|---|---|--:|--:|--:|---|")
         for provider, e in sorted(
             cost["by_provider"].items(),
-            key=lambda kv: -(kv[1]["batch_cost_usd"] + kv[1]["full_price_cost_usd"]),
+            key=lambda kv: -(
+                kv[1]["batch_cost_usd"]
+                + kv[1]["full_price_cost_usd"]
+                + kv[1]["non_batchable_cost_usd"]
+            ),
         ):
             lines.append(
                 f"| {provider} | {'yes' if e['batch_attempted'] else 'no'} "
                 f"| {e['batch_cost_usd']} | {e['full_price_cost_usd']} "
+                f"| {e['non_batchable_cost_usd']} "
                 f"| {e['n_batch_calls']}/{e['n_full_price_calls']} |"
             )
         lines.append("")
         lines.append(
-            "_Full-price spend on a provider with `batch attempted = no` is expected "
-            "(grounding, or a provider excluded via `PYTHIA_BATCH_PROVIDERS`) and is "
-            "not counted as lost discount._"
+            "_`not batchable` is grounding, adversarial checks, scenarios and Sibyl — "
+            "no batch family exists for them, so that spend is expected at full price "
+            "and is NOT counted as lost discount. Full-price spend on a provider with "
+            "`batch attempted = no` (excluded via `PYTHIA_BATCH_PROVIDERS`) is likewise "
+            f"excluded. Not batchable this run: ${cost['non_batchable_cost_usd']}._"
         )
         lines.append("")
     elif cost.get("reason"):

--- a/scripts/ci/tests/test_batch_economics.py
+++ b/scripts/ci/tests/test_batch_economics.py
@@ -237,23 +237,26 @@ def _db_with_calls(tmp_path):
         """
         CREATE TABLE llm_calls (
             run_id TEXT, hs_run_id TEXT, provider TEXT,
-            cost_usd DOUBLE, usage_json TEXT
+            cost_usd DOUBLE, usage_json TEXT, phase TEXT, call_type TEXT
         )
         """
     )
     batch = '{"service_tier": "batch"}'
     plain = "{}"
 
-    def add(run_id, hs_run_id, provider, cost, usage):
-        con.execute("INSERT INTO llm_calls VALUES (?,?,?,?,?)", [run_id, hs_run_id, provider, cost, usage])
+    def add(run_id, hs_run_id, provider, cost, usage, phase, call_type):
+        con.execute(
+            "INSERT INTO llm_calls VALUES (?,?,?,?,?,?,?)",
+            [run_id, hs_run_id, provider, cost, usage, phase, call_type],
+        )
 
     # This run: openai batching failed (full price), google batched.
-    add(FC_RUN, None, "openai", 2.00, plain)
-    add(FC_RUN, None, "google", 1.00, batch)
-    # Grounding: never batchable, must not count as lost discount.
-    add(None, HS_RUN, "brave", 0.50, plain)
+    add(FC_RUN, None, "openai", 2.00, plain, "spd_v2", "spd_v2")
+    add(FC_RUN, None, "google", 1.00, batch, "spd_v2", "spd_v2")
+    # Grounding: no batch family exists, so this must never count as a loss.
+    add(None, HS_RUN, "brave", 0.50, plain, "hs_triage", "rc_grounding")
     # A different pipeline in the same travelling DB — must be excluded.
-    add("fc_other", None, "openai", 60.00, plain)
+    add("fc_other", None, "openai", 60.00, plain, "spd_v2", "spd_v2")
     con.close()
     return path
 
@@ -349,12 +352,13 @@ def test_no_cost_warning_when_everything_batched(tmp_path, capsys):
         """
         CREATE TABLE llm_calls (
             run_id TEXT, hs_run_id TEXT, provider TEXT,
-            cost_usd DOUBLE, usage_json TEXT
+            cost_usd DOUBLE, usage_json TEXT, phase TEXT, call_type TEXT
         )
         """
     )
     con.execute(
-        "INSERT INTO llm_calls VALUES (?, NULL, 'google', 1.0, '{\"service_tier\": \"batch\"}')",
+        "INSERT INTO llm_calls VALUES (?, NULL, 'google', 1.0, "
+        "'{\"service_tier\": \"batch\"}', 'spd_v2', 'spd_v2')",
         [FC_RUN],
     )
     con.execute(
@@ -384,3 +388,77 @@ def test_missing_llm_calls_table_still_returns_zero(tmp_path):
     path = _db(tmp_path)
     report = _run_scoped(path, tmp_path)
     assert report["cost"]["available"] is False
+
+
+def test_non_batchable_phases_are_not_counted_as_lost_discount(tmp_path):
+    """Grounding on a provider that also batches is not a lost discount.
+
+    Found on the 2026-07-30 SOM run: google showed "lost $0.0556 (41.6% of
+    batchable)" when that spend was grounding and adversarial synthesis, for
+    which no batch family exists. `batch_attempted` is provider-level, so any
+    unbatchable phase on a batching provider was miscounted — the same
+    unactionable-denominator problem the cost view was built to fix.
+    """
+    path = _db(tmp_path)
+    con = duckdb.connect(path)
+    con.execute(
+        """
+        CREATE TABLE llm_calls (
+            run_id TEXT, hs_run_id TEXT, provider TEXT,
+            cost_usd DOUBLE, usage_json TEXT, phase TEXT, call_type TEXT
+        )
+        """
+    )
+    batch = '{"service_tier": "batch"}'
+    # Google batched its RC passes...
+    con.execute(
+        "INSERT INTO llm_calls VALUES (NULL, ?, 'google', 0.08, ?, 'hs_triage', 'rc_pass_1')",
+        [HS_RUN, batch],
+    )
+    # ...and also ran grounding + adversarial synthesis, which cannot be batched.
+    for call_type, cost in (("rc_grounding", 0.04), ("adversarial_synthesis", 0.02)):
+        con.execute(
+            "INSERT INTO llm_calls VALUES (NULL, ?, 'google', ?, '{}', 'hs_triage', ?)",
+            [HS_RUN, cost, call_type],
+        )
+    con.execute(
+        "INSERT INTO llm_batches VALUES "
+        "('bg','google','hs_rc','hs_submit','gemini-3.5-flash','collected',?,4,4,0,0,0,NULL,NULL)",
+        [PIPE],
+    )
+    con.close()
+
+    cost = _run_scoped(path, tmp_path)["cost"]
+    assert cost["lost_discount_cost_usd"] == pytest.approx(0.0)
+    assert cost["lost_discount_pct_of_batchable"] == pytest.approx(0.0)
+    # The unbatchable spend is still reported — just not as a loss.
+    assert cost["non_batchable_cost_usd"] == pytest.approx(0.06)
+    assert cost["by_provider"]["google"]["non_batchable_cost_usd"] == pytest.approx(0.06)
+
+
+def test_batchable_spend_that_missed_a_batch_is_still_counted_as_lost(tmp_path):
+    """The narrowing must not hide a genuine loss: an unbatched SPD call."""
+    path = _db(tmp_path)
+    con = duckdb.connect(path)
+    con.execute(
+        """
+        CREATE TABLE llm_calls (
+            run_id TEXT, hs_run_id TEXT, provider TEXT,
+            cost_usd DOUBLE, usage_json TEXT, phase TEXT, call_type TEXT
+        )
+        """
+    )
+    con.execute(
+        "INSERT INTO llm_calls VALUES (?, NULL, 'openai', 1.50, '{}', 'spd_v2', 'spd_v2')",
+        [FC_RUN],
+    )
+    con.execute(
+        "INSERT INTO llm_batches VALUES "
+        "('bo','openai','spd_v2','fc','gpt-5.6-sol','collected',?,4,0,0,4,0,NULL,NULL)",
+        [PIPE],
+    )
+    con.close()
+
+    cost = _run_scoped(path, tmp_path)["cost"]
+    assert cost["lost_discount_cost_usd"] == pytest.approx(1.50)
+    assert cost["lost_discount_pct_of_batchable"] == pytest.approx(100.0)


### PR DESCRIPTION
Found by reading the 2026-07-30 SOM test run's own diagnostics — a false positive in the cost view I added in #826.

## The defect

Stage 3 reported:

```
google | batch attempted=yes | batch $0.0782 | full $0.0556     → "lost 41.6% of batchable"
```

That `$0.0556` was **RC grounding and adversarial synthesis** — phases for which no batch family exists. It was never going to be discounted, so calling it a lost discount is precisely the unactionable-denominator problem the cost view was built to eliminate.

Cause: `batch_attempted` is **provider-level**. Once a provider creates any batch, all its full-price spend counted as lost. Gemini serves both batched RC passes *and* unbatchable grounding, so it was mislabelled on every run.

## The fix

Only four families are ever batched:

| family | identified by |
|---|---|
| `spd_v2`, `binary_v2` | `phase` |
| `hs_rc`, `hs_triage` | **`call_type`** (`rc_pass_%` / `triage_pass_%`) — every HS row shares `phase='hs_triage'`, grounding included, so phase alone cannot separate a model pass from grounding |

Spend is now classified three ways, and the third is reported rather than hidden:

- **batched** — carried `service_tier=batch`
- **lost** — batchable but paid full price (the real signal)
- **not batchable** — grounding, adversarial, scenarios, Sibyl: expected at full price, its own column

Pre-`call_type` DBs fall back to the two forecaster phases rather than over-claiming.

## Verification

Re-ran the reporter against the staged DB that produced the false alarm:

```
$0.0 of $0.0782 batchable spend paid full price (0.0% of batchable, 0.0% of the $0.2288 run)

| provider | batch attempted | batch $ | lost $ | not batchable $ | calls (batch/lost) |
| google   | yes             |  0.0782 |    0.0 |          0.0556 | 5/0                |
| brave    | no              |     0.0 |    0.0 |           0.095 | 0/0                |
```

google's loss goes `$0.0556 / 41.6%` → `$0.0 / 0.0%`, the unbatchable spend is visible as its own figure, and the `$0.0782` genuinely batched is still credited.

Tests: `scripts/ci/tests/test_batch_economics.py` — 20 passed, including two new ones pinning **both** directions: grounding on a batching provider is not a loss, and a genuinely unbatched SPD call still is (so the narrowing can't hide a real problem). The existing fixtures also gained `phase`/`call_type`, which production rows always carry and the fixtures previously omitted.

## Correction

An earlier claim of mine in this session was wrong: `llm_batches.model_id` being NULL was **not** a separate defect. `group_model` was always passed through — it was `None` for OpenAI only because of the mixed-model grouping bug fixed in #828, and it now populates correctly (`model=gpt-5.6-sol`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrMwZBzyVv56au1DuWokhD

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrMwZBzyVv56au1DuWokhD)_