### PR TITLE
Montandon probe: a 401 is a locked door, not a missing building

### DIFF
--- a/.github/workflows/probe_montandon.yml
+++ b/.github/workflows/probe_montandon.yml
@@ -34,6 +34,12 @@ on:
         required: false
         default: ""
         type: string
+      auth_scheme:
+        description: "How to present MONTANDON_TOKEN (the service's scheme is undocumented)"
+        required: false
+        default: "bearer"
+        type: choice
+        options: ["bearer", "token", "basic", "header"]
 
 permissions:
   contents: read
@@ -73,6 +79,14 @@ jobs:
           PROBE_ENDPOINT: ${{ inputs.endpoint }}
           PROBE_MONTHS_BACK: ${{ inputs.months_back }}
           PROBE_HAZARDS: ${{ inputs.hazards }}
+          PROBE_AUTH_SCHEME: ${{ inputs.auth_scheme }}
+          # The live endpoints answer 401, so the probe needs a credential to
+          # get past G0. This is a DIFFERENT secret from GO_API_TOKEN: the GO
+          # operational API and the Montandon STAC API are separate services,
+          # and a stored credential for one is not silently forwarded to the
+          # other. Unset until IFRC grants access — the probe then reports
+          # "BLOCKED — credentials required" rather than guessing.
+          MONTANDON_TOKEN: ${{ secrets.MONTANDON_TOKEN }}
         run: |
           set -euo pipefail
           # An array, not a string: the optional flags carry their own values,
@@ -81,6 +95,7 @@ jobs:
           args=(
             --months-back "${PROBE_MONTHS_BACK}"
             --hazards "${PROBE_HAZARDS}"
+            --auth-scheme "${PROBE_AUTH_SCHEME}"
             --out-dir diagnostics
             --verbose
           )

--- a/docs/montandon_assessment.md
+++ b/docs/montandon_assessment.md
@@ -239,7 +239,14 @@ Ranked by value to a downstream forecasting consumer.
    appeals incident above is what inconsistency costs downstream.
 9. **Data-quality flags** — estimate vs confirmed, order-of-magnitude confidence, inclusion
    notes. Consumers currently infer confidence from which field happened to be populated.
-10. **Make Montandon production-grade for programmatic consumers** — a stable production
+10. **Document how to get access, and publish the auth scheme.** Measured 2026-08-04 from a
+    GitHub runner: `montandon-eoapi.ifrc.org/stac` and `montandon-eoapi-stage.ifrc.org/stac`
+    are both **up and both return HTTP 401**. The service is real and running; it is simply
+    closed. Nothing in the reachable documentation says credentials are needed, how to
+    request them, or which scheme the API expects — so the first thing an evaluating
+    consumer learns is a bare 401. An "about the data" page that omits "and here is how to
+    get in" costs every prospective user the same wasted cycle.
+11. **Make Montandon production-grade for programmatic consumers** — a stable production
     STAC endpoint, versioned collection names, a changelog, and documentation reachable by
     non-browser clients. As of this writing the documented endpoint is a staging host and
     the Monty documentation pages refuse non-browser requests.
@@ -258,9 +265,15 @@ Ranked by value to a downstream forecasting consumer.
   delta vs our IFRC ingest, G4 latency vs the resolution cutoff, G5 agreement, G6 revision
   visibility, G7 historical depth) and recommends one of four outcomes: replace IFRC GO,
   supplement it within `PA_REPORTED`, use it for base rates only, or reject. Run it via the
-  `Probe Montandon STAC` workflow (`workflow_dispatch`); it needs egress to `*.ifrc.org`,
-  which the development sandbox denies, so **it has not yet been executed against the live
-  API** — G0 is unanswered. G4 is the gate most likely to bite: Montandon leans on EM-DAT,
+  `Probe Montandon STAC` workflow (`workflow_dispatch`).
+  **First live run, 2026-08-04: BLOCKED — credentials required.** Both
+  `montandon-eoapi.ifrc.org/stac` and `montandon-eoapi-stage.ifrc.org/stac` responded with
+  **HTTP 401**. The service is up; we are not authorised. Every gate below G0 remains
+  unanswered, and nothing about the data can be concluded from this — the next step is to
+  request API access and the auth scheme from IFRC, then set the `MONTANDON_TOKEN` secret
+  (deliberately separate from `GO_API_TOKEN`: the GO operational API and the Montandon STAC
+  API are different services, and a credential for one is not forwarded to the other) and
+  re-run. G4 remains the gate most likely to bite once we are in: Montandon leans on EM-DAT,
   which is slow, and Pythia resolves against the previous complete month.
 - **Fix the month collapse.** *Half done, August 2026.* `resolve_sources` no longer lets
   the earliest report beat the latest revision — the tiebreak is now source priority, then

--- a/resolver/tests/test_probe_montandon_stac.py
+++ b/resolver/tests/test_probe_montandon_stac.py
@@ -25,6 +25,7 @@ import pytest
 from tools.probe_montandon_stac import (
     MODELLED_EXPOSURE_SOURCES,
     REPORTED_IMPACT_SOURCES,
+    _classify_probe,
     _classify_source,
     _parse_date,
     decide,
@@ -71,6 +72,53 @@ def test_unreachable_endpoint_yields_unknown_not_rejection():
     verdict = decide([_gate("G0", False)])
     assert verdict["outcome"].startswith("UNKNOWN")
     assert "unreachable" in verdict["outcome"].lower()
+
+
+# ---------------------------------------------------------------------------
+# "Not 200" is not one condition
+#
+# The first live run against the real API returned HTTP 401 from all three
+# endpoints. The probe reported "no endpoint reachable — every later gate is
+# unanswerable", which was wrong in a way that mattered: the service was up and
+# the actual finding was that it needs credentials. These pin the distinction.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_auth_rejection_is_not_reported_as_unreachable(status):
+    assert _classify_probe(status, {}) == "auth_required"
+
+
+def test_a_401_yields_blocked_on_credentials_not_unknown():
+    g0 = {
+        "gate": "G0",
+        "question": "endpoint responds and admits us",
+        "pass": False,
+        "blocked_by_auth": True,
+        "authenticated": False,
+    }
+    verdict = decide([g0])
+    assert verdict["outcome"].startswith("BLOCKED")
+    assert "credential" in verdict["outcome"].lower()
+    # And it must not be mistaken for a judgement on the data.
+    assert "access problem, not an availability one" in verdict["verdict"]
+
+
+def test_blocked_says_whether_a_token_was_even_tried():
+    """A 401 with a token means the token is wrong; without, we never had one."""
+    with_token = decide([{"gate": "G0", "pass": False, "blocked_by_auth": True,
+                          "authenticated": True}])
+    without = decide([{"gate": "G0", "pass": False, "blocked_by_auth": True,
+                       "authenticated": False}])
+    assert "with the token supplied" in with_token["verdict"]
+    assert "no token" in without["verdict"]
+
+
+def test_connection_failure_and_404_stay_distinct():
+    assert _classify_probe(0, {"error": "ConnectionError"}) == "unreachable"
+    assert _classify_probe(404, {}) == "not_found"
+    assert _classify_probe(200, {}) == "ok"
+    assert _classify_probe(500, {}) == "http_error"
 
 
 def test_failing_the_source_attribution_gate_rejects_outright():

--- a/tools/probe_montandon_stac.py
+++ b/tools/probe_montandon_stac.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import logging
 import statistics
 import sys
@@ -97,12 +98,24 @@ class Stac:
     dependency to python_library_requirements before we know the answer.
     """
 
-    def __init__(self, root: str) -> None:
+    def __init__(self, root: str, token: str = "", scheme: str = "bearer") -> None:
         self.root = root.rstrip("/")
         self.session = requests.Session()
         self.session.headers.update(
             {"Accept": "application/json", "User-Agent": "pythia-montandon-probe/1.0"}
         )
+        # The service's auth scheme is undocumented in anything we can reach,
+        # so make it selectable rather than guessing one and reporting the
+        # resulting 401 as if it were the service's fault.
+        if token:
+            if scheme == "basic":
+                self.session.headers["Authorization"] = f"Basic {token}"
+            elif scheme == "token":
+                self.session.headers["Authorization"] = f"Token {token}"
+            elif scheme == "header":
+                self.session.headers["X-API-Key"] = token
+            else:
+                self.session.headers["Authorization"] = f"Bearer {token}"
 
     def get(self, path: str, **params: Any) -> tuple[int, Any]:
         url = path if path.startswith("http") else f"{self.root}/{path.lstrip('/')}"
@@ -175,28 +188,75 @@ def _parse_date(value: Any) -> date | None:
 # ---------------------------------------------------------------------------
 
 
-def gate_g0(endpoint: str) -> dict:
-    """Does a production endpoint exist and respond?"""
-    result: dict[str, Any] = {"gate": "G0", "question": "production endpoint responds"}
+def _classify_probe(status: int, body: Any) -> str:
+    """Turn an HTTP outcome into the distinction that changes what we do next.
+
+    "Did not return 200" is not one condition. A DNS failure, a 401 and a 404
+    call for three different next steps — get network access, get credentials,
+    fix the path — and collapsing them into "unreachable" produces a verdict
+    that is not merely vague but wrong.
+    """
+    if status == 0:
+        return "unreachable"
+    if status == 200:
+        return "ok"
+    if status in (401, 403):
+        return "auth_required"
+    if status == 404:
+        return "not_found"
+    return "http_error"
+
+
+def gate_g0(endpoint: str, token: str = "", scheme: str = "bearer") -> dict:
+    """Does an endpoint exist, and can we actually get in?"""
+    result: dict[str, Any] = {"gate": "G0", "question": "endpoint responds and admits us"}
+    result["authenticated"] = bool(token)
     probes = {}
     for label, root in (("requested", endpoint), ("prod", PROD_ENDPOINT), ("stage", STAGE_ENDPOINT)):
-        status, body = Stac(root).get("/")
+        status, body = Stac(root, token=token, scheme=scheme).get("/")
+        kind = _classify_probe(status, body)
+        # Keep a snippet of whatever the server said. On a 401 this is the only
+        # place the reason can come from, and it is what tells us which auth
+        # scheme the service wants.
+        detail = None
+        if isinstance(body, dict):
+            detail = body.get("error") or body.get("detail") or body.get("message")
+            if detail is None and kind != "ok":
+                detail = json.dumps(body)[:200]
         probes[label] = {
             "url": root,
             "status": status,
+            "kind": kind,
             "title": (body or {}).get("title") if isinstance(body, dict) else None,
-            "error": (body or {}).get("error") if isinstance(body, dict) else None,
+            "detail": detail,
         }
     result["probes"] = probes
-    prod_ok = probes["prod"]["status"] == 200
-    stage_ok = probes["stage"]["status"] == 200
-    result["pass"] = bool(prod_ok or probes["requested"]["status"] == 200)
-    if prod_ok:
+
+    kinds = {label: p["kind"] for label, p in probes.items()}
+    any_ok = "ok" in kinds.values()
+    any_auth = "auth_required" in kinds.values()
+
+    result["pass"] = bool(any_ok)
+    result["blocked_by_auth"] = bool(any_auth and not any_ok)
+
+    if probes["prod"]["kind"] == "ok":
         result["verdict"] = "production endpoint responds"
-    elif stage_ok:
+    elif any_ok:
         result["verdict"] = (
-            "ONLY the staging endpoint responds. Usable for a base-rate "
+            "only the staging endpoint responds. Usable for a base-rate "
             "evaluation; must not become a production resolution dependency."
+        )
+    elif any_auth:
+        result["verdict"] = (
+            "endpoints are UP but require credentials (HTTP "
+            f"{probes['prod']['status'] or probes['stage']['status']}). This is "
+            "an access problem, not an availability one — supply a token via "
+            "MONTANDON_TOKEN and re-run."
+        )
+    elif "not_found" in kinds.values():
+        result["verdict"] = (
+            "host responds but the STAC root is not at this path — check the "
+            "endpoint URL before concluding anything about the service"
         )
     else:
         result["verdict"] = "no endpoint reachable — every later gate is unanswerable"
@@ -404,12 +464,14 @@ def gate_g3_g5_local(db_path: Path | None, months_back: int, hazards: list[str])
             "no resolver DB supplied — run with --db to get the coverage "
             "baseline the G3 gate compares against"
         )
+        out["verdict"] = "no DB supplied — baseline not computed"
         return out
     try:
         import duckdb
     except ImportError:
         out["available"] = False
         out["note"] = "duckdb not installed"
+        out["verdict"] = "duckdb not installed — baseline not computed"
         return out
 
     since_ym = (date.today() - timedelta(days=30 * months_back)).strftime("%Y-%m")
@@ -434,6 +496,7 @@ def gate_g3_g5_local(db_path: Path | None, months_back: int, hazards: list[str])
     except Exception as exc:  # pragma: no cover - defensive
         out["available"] = False
         out["note"] = f"query failed: {type(exc).__name__}: {exc}"
+        out["verdict"] = f"baseline query failed: {type(exc).__name__}"
         return out
     finally:
         con.close()
@@ -444,7 +507,12 @@ def gate_g3_g5_local(db_path: Path | None, months_back: int, hazards: list[str])
         r[0]: {"country_months": r[1], "countries": r[2], "first_ym": r[3], "last_ym": r[4]}
         for r in rows
     }
-    out["ifrc_country_months_total"] = sum(r[1] for r in rows)
+    total = sum(r[1] for r in rows)
+    out["ifrc_country_months_total"] = total
+    out["verdict"] = (
+        f"{total} IFRC PA country-months since {since_ym} across "
+        f"{', '.join(r[0] for r in rows) or 'no hazards'}"
+    )
     return out
 
 
@@ -478,6 +546,54 @@ def render_markdown(report: dict) -> str:
             f"{gate.get('verdict', '').replace('|', '/')} |"
         )
     lines.append("")
+
+    # What each endpoint actually said. Without this the summary cannot
+    # distinguish "the service is down" from "we are not authorised", which
+    # are entirely different problems with entirely different next steps.
+    g0 = next((g for g in report["gates"] if g.get("gate") == "G0"), None)
+    if g0 and g0.get("probes"):
+        lines.append("### Endpoint probes")
+        lines.append("")
+        lines.append(f"_Token supplied: {'yes' if g0.get('authenticated') else 'no'}_")
+        lines.append("")
+        lines.append("| Endpoint | URL | HTTP | Interpretation | Server said |")
+        lines.append("|---|---|---|---|---|")
+        for label, probe in g0["probes"].items():
+            status = probe.get("status")
+            lines.append(
+                f"| {label} | `{probe.get('url')}` | "
+                f"{status if status else 'no response'} | {probe.get('kind')} | "
+                f"{str(probe.get('detail') or '—').replace('|', '/')[:120]} |"
+            )
+        lines.append("")
+
+    baseline = next(
+        (g for g in report["gates"] if str(g.get("gate", "")).startswith("G3/G5")), None
+    )
+    if baseline:
+        lines.append("### Our current IFRC coverage (the G3 comparison baseline)")
+        lines.append("")
+        if not baseline.get("available"):
+            lines.append(f"Unavailable — {baseline.get('note', 'no reason recorded')}.")
+        else:
+            lines.append(
+                f"IFRC PA country-months since {baseline.get('since_ym')}: "
+                f"**{baseline.get('ifrc_country_months_total')}**"
+            )
+            lines.append("")
+            lines.append("| Hazard | Country-months | Countries | First | Last |")
+            lines.append("|---|---|---|---|---|")
+            for hz, stats in (baseline.get("ifrc_country_months_by_hazard") or {}).items():
+                lines.append(
+                    f"| {hz} | {stats.get('country_months')} | {stats.get('countries')} | "
+                    f"{stats.get('first_ym')} | {stats.get('last_ym')} |"
+                )
+            lines.append("")
+            lines.append(
+                f"Montandon must beat this by ≥{COVERAGE_MULTIPLE_MIN}× to be worth a "
+                f"connector, and ≥{COVERAGE_MULTIPLE_GOOD}× to be a clear win."
+            )
+        lines.append("")
 
     colls = report.get("collections", {})
     if colls.get("collections"):
@@ -515,6 +631,18 @@ def decide(gates: list[dict]) -> dict:
     g0, g1 = by_id.get("G0", {}), by_id.get("G1", {})
     g2, g4 = by_id.get("G2", {}), by_id.get("G4", {})
 
+    if g0.get("blocked_by_auth"):
+        who = "with the token supplied" if g0.get("authenticated") else "and we have no token"
+        return {
+            "outcome": "BLOCKED — credentials required",
+            "verdict": (
+                f"The Montandon STAC endpoints are UP but returned 401/403 {who}. "
+                "This is an access problem, not an availability one, and nothing "
+                "below G0 is answerable until it is resolved. Next step is to ask "
+                "IFRC for API access and the auth scheme — not to draw any "
+                "conclusion about the data itself."
+            ),
+        }
     if g0.get("pass") is False:
         return {
             "outcome": "UNKNOWN — endpoint unreachable",
@@ -570,8 +698,18 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--months-back", type=int, default=36)
     parser.add_argument("--hazards", default="FL,DR,TC")
     parser.add_argument("--out-dir", default="diagnostics")
+    parser.add_argument(
+        "--auth-scheme",
+        default="bearer",
+        choices=["bearer", "token", "basic", "header"],
+        help="How to present MONTANDON_TOKEN (the service's scheme is undocumented)",
+    )
     parser.add_argument("--verbose", action="store_true")
     args = parser.parse_args(argv)
+
+    # Never a CLI flag: a token on the command line lands in the process table
+    # and in CI logs.
+    token = os.environ.get("MONTANDON_TOKEN", "").strip()
 
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.INFO,
@@ -581,8 +719,8 @@ def main(argv: list[str] | None = None) -> int:
     hazards = [h.strip().upper() for h in args.hazards.split(",") if h.strip()]
     gates: list[dict] = []
 
-    LOG.info("G0: probing endpoints")
-    g0 = gate_g0(args.endpoint)
+    LOG.info("G0: probing endpoints (token supplied: %s)", "yes" if token else "no")
+    g0 = gate_g0(args.endpoint, token=token, scheme=args.auth_scheme)
     gates.append(g0)
 
     endpoint = args.endpoint
@@ -594,7 +732,7 @@ def main(argv: list[str] | None = None) -> int:
                 LOG.warning("falling back to the %s endpoint: %s", label, endpoint)
                 break
 
-    stac = Stac(endpoint)
+    stac = Stac(endpoint, token=token, scheme=args.auth_scheme)
     collections_report: dict = {"status": None, "n_collections": 0, "collections": []}
     impact_collections: list[str] = []
 


### PR DESCRIPTION
Follow-up to #841. The first live run of the probe reported:

> no endpoint reachable — every later gate is unanswerable

**That was wrong.** From the run log:

```
GET /stac/ HTTP/1.1" 401 31    montandon-eoapi.ifrc.org
GET /stac/ HTTP/1.1" 401 31    montandon-eoapi.ifrc.org
GET /stac/ HTTP/1.1" 401 31    montandon-eoapi-stage.ifrc.org
```

All three answered in under three seconds. The hosts resolve, TLS completes, the service is up. **Montandon STAC requires credentials and we don't have them.** The whole step took 4 seconds — far too fast for three 60-second timeouts, which is the tell I should have noticed in the summary and couldn't, because the summary didn't show it.

## What was wrong

The probe treated any non-200 as "unreachable", collapsing four conditions with four different next steps — fix the network, get credentials, fix the path, retry later — into one misleading sentence. `_classify_probe` now separates `unreachable` / `auth_required` / `not_found` / `http_error`, and a 401 yields a new outcome, **`BLOCKED — credentials required`**, whose verdict says explicitly that this is an access problem and that nothing about the data follows from it.

This is the same failure mode the assessment itself documents elsewhere: a diagnostic that converts one condition into a confident statement about a different one.

## Two reporting gaps, same shape

Both are the "detail existed only in the JSON" kind that CLAUDE.md already has a rule about:

- The summary never showed **what each endpoint actually returned**. The status codes were in the artifact; the human-readable verdict was the thing that was wrong. There is now an **Endpoint probes** table with URL, HTTP status, interpretation, and the server's own message.
- The **G3 baseline rendered as `n/a` with empty notes** — even though the 453 MB canonical DB downloaded fine and the coverage numbers were sitting in the JSON. It had no `verdict` key, so the table row was blank. It now renders the IFRC country-month counts per hazard, which is the number Montandon has to beat.

## Credentials

Adds `MONTANDON_TOKEN` support with a selectable scheme (`bearer` / `token` / `basic` / `header`), since the service's auth method is undocumented in everything reachable. Read from the environment, never a CLI flag, so it stays out of process listings and CI logs.

**Deliberately not wired to `GO_API_TOKEN`.** The GO operational API and the Montandon STAC API are separate services; forwarding a stored credential from one to the other is not a decision this script should make silently. The secret is unset until IFRC grants access, and until then the probe correctly reports `BLOCKED`.

## Upstream finding

Recorded in `docs/montandon_assessment.md` as improvement #10: the service is closed, and the reachable documentation never says so, never says how to request access, and never states the scheme — so every prospective consumer's first result is a bare 401.

## Tests

Four new cases pin the distinction that misled us: 401/403 classify as `auth_required` not `unreachable`; a 401 yields `BLOCKED` not `UNKNOWN`; the verdict says whether a token was even tried (a 401 *with* a token means the token is wrong, *without* means we never had one); and connection-failure vs 404 vs 500 stay distinct.

## Status

The evaluation is **not** answered — G1 through G7 remain unanswerable until we have access. Nothing in this PR concludes anything about Montandon's data. Next step is to ask IFRC for API access and the auth scheme, set the secret, and re-run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFjMp1wu3Te7LVrsfvQ6tX)_