### PR TITLE
Fix five defects the first live interpreter report exposed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,8 @@ entries. When you add a failure-mode entry with a `**Rule:**` line, add the rule
 - The PACK decides which forecasts the report covers and under which heading; the model copies that decision and the validator holds it to the list. A report that promotes an entry is making a claim on the model's authority, not the system's.
 - A question record budget is spent in REPORT order, never attention order — otherwise a row the report must cover loses its record to a question the report never mentions, and any covered row that still loses one is named rather than counted.
 - The report prints names, never codes, and figures as sentences: no "% of maximum", no "1/87.5x". Both were shipped and both confused readers.
+- A template may only name a `{{fig:...}}` key some producer declares (`packs._ATTENTION_FIG_KEYS` / `_RUN_SUMMARY_KEYS` / `_PERFORMANCE_KEYS`) — an undeclared key renders `[figure unavailable]` and fails the whole report's referential check.
+- The style check's code test matches the REAL ISO3 set, never any three-capital run: FAO, IOM and "Phase III" are ordinary humanitarian prose, and a validator that cries wolf gets ignored.
 - The printed map is drawn by `interpreter/mapviz.py` from the same table, preference order and scaling as `/v1/interpreter/attention_map` — the dashboard's choropleth is JavaScript and a PDF cannot run it, so the two must be kept honest by construction, not by hand.
 
 **Release publishing**

--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -169,6 +169,24 @@ prompt assembly write question records in report order, so the rows the report
 must cover are the last thing a token budget gives up; anything that still
 loses its record is named, in the manifest and in the prompt.
 
+## The figure-key contract
+
+A template may only name a `{{fig:...}}` key that something actually produces:
+`packs._ATTENTION_FIG_KEYS` (per question), `_RUN_SUMMARY_KEYS` (run level) or
+`_PERFORMANCE_KEYS` (scored pack). A key nothing produces renders as
+`[figure unavailable]` and fails the referential check for the whole report.
+
+`interpreter/tests/test_selection_names_charts.py::TestTemplateFigureContract`
+scans every template for placeholder keys and fails if one is not produced. It
+exists because `ev_multiple` shipped exactly that way: the system prompt told
+the model to write it, the selection module computed it onto every attention
+row, and the figure map never exposed it, so the first live report failed
+validation with every worsening entry's headline number unresolvable.
+
+`figure_refs` entries are normalised before lookup, so `eiv_nominal`,
+`fig:eiv_nominal` and `{{fig:eiv_nominal}}` all resolve. The prefix carries no
+meaning and rejecting it failed a report over punctuation.
+
 ## Validation (Phase 4 — `interpreter/validate.py`)
 
 Six checks run after generation, before storage; each is reported

--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -213,7 +213,10 @@ failures stay inspectable):
 5. **style** — the house rules that can be checked mechanically: no em or
    en dashes, no banned words (`BANNED_PHRASES`), no "not X, but Y", no
    "on the other hand", and no bare ISO3 / metric enum / `HZ/METRIC` code
-   where the reader needs a name. Deliberately narrow: rhythm, variety and
+   where the reader needs a name. The code check matches the REAL ISO3 set
+   from `resolver/data/countries.csv`, never any three-capital run: FAO, IOM
+   and "Phase III" are ordinary humanitarian prose, and flagging them failed a
+   correct report. Deliberately narrow: rhythm, variety and
    the habit of joining clauses with "and" are asked for in the prompt and
    judged by a reader, and a lint that scored them would fail honest prose.
 6. **categories** — the pack decides which forecasts the report covers and

--- a/interpreter/names.py
+++ b/interpreter/names.py
@@ -88,6 +88,15 @@ def country_name(iso3: str | None) -> str:
     return _country_map().get(code, code)
 
 
+def iso3_codes() -> frozenset[str]:
+    """Every ISO3 code the country table knows.
+
+    Used by the style check to tell a country code from an agency acronym:
+    FAO and IOM are prose, SOM and NIC are codes a reader cannot decode.
+    """
+    return frozenset(_country_map())
+
+
 def hazard_name(hazard_code: str | None) -> str:
     code = (hazard_code or "").strip().upper()
     return HAZARD_NAMES.get(code, code or "Unknown hazard")

--- a/interpreter/packs.py
+++ b/interpreter/packs.py
@@ -159,8 +159,14 @@ def pack_categories(pack: Pack) -> dict[str, tuple[str | None, str | None]]:
 # Figures — the values {{fig:...}} placeholders resolve against
 # ---------------------------------------------------------------------------
 
+# Every key here must be a column the attention index actually carries, and
+# every {{fig:...}} key the templates instruct the model to use must be here.
+# test_template_figure_keys_are_all_produced pins the second half: a template
+# naming a key nothing produces renders [figure unavailable] in the report and
+# fails the referential check, which is how ev_multiple shipped broken.
 _ATTENTION_FIG_KEYS = (
-    "js_vs_baserate", "log_ev_ratio", "eiv_nominal", "eiv_per_100k",
+    "js_vs_baserate", "log_ev_ratio", "ev_multiple",
+    "eiv_nominal", "eiv_per_100k",
     "rc_level", "rc_score", "triage_score", "attention_rank",
     "baserate_source",
 )
@@ -265,6 +271,19 @@ def _weighted_skill(rows: list[dict[str, Any]], family: str) -> dict[str, float]
     return out
 
 
+# Run-level figure keys (they belong to the run, not to a question). Same
+# contract as _ATTENTION_FIG_KEYS: a template may only name keys listed here.
+_RUN_SUMMARY_KEYS = (
+    "countries_scanned",
+    "countries_with_questions",
+    "countries_track1",
+    "countries_track2",
+    "n_questions",
+    "n_above_base_rate",
+    "n_below_base_rate",
+)
+
+
 def run_summary_figures(pack: Pack) -> dict[str, Any]:
     """Scan-scope counts for the report's opening paragraph.
 
@@ -275,15 +294,7 @@ def run_summary_figures(pack: Pack) -> dict[str, Any]:
     manifest = pack.manifest or {}
     summary = manifest.get("run_summary") or {}
     out: dict[str, Any] = {}
-    for key in (
-        "countries_scanned",
-        "countries_with_questions",
-        "countries_track1",
-        "countries_track2",
-        "n_questions",
-        "n_above_base_rate",
-        "n_below_base_rate",
-    ):
+    for key in _RUN_SUMMARY_KEYS:
         value = summary.get(key)
         if value is not None:
             out[key] = value
@@ -322,10 +333,20 @@ def question_distributions(pack: Pack) -> dict[str, dict[str, Any]]:
     return out
 
 
+# Performance figure keys (scored pack only). Derived from the family loop in
+# _weighted_skill so the declaration cannot drift from what it emits.
+_PERFORMANCE_FAMILIES = ("spd", "binary")
+_PERFORMANCE_KEYS = tuple(
+    f"{stem}_{family}"
+    for family in _PERFORMANCE_FAMILIES
+    for stem in ("mean_brier", "skill_brier", "climatology_brier")
+) + ("n_scored_questions",)
+
+
 def performance_figures(pack: Pack) -> dict[str, Any]:
     """Pack-level figures for the performance prose (scored pack only)."""
     figs: dict[str, Any] = {}
-    for family in ("spd", "binary"):
+    for family in _PERFORMANCE_FAMILIES:
         figs.update(_weighted_skill(pack.rollups, family))
     n = pack.manifest.get("n_scored_questions")
     if n is not None:

--- a/interpreter/templates/v2/current_run.md
+++ b/interpreter/templates/v2/current_run.md
@@ -1,5 +1,8 @@
 # This month's forecast run
 
+Set `kind` in your output to exactly `{{KIND}}`. That is a fact about this
+request, not a judgement; getting it wrong fails the report.
+
 Below is the pack for the run you are reporting on. Work only from it.
 
 {{PACK}}

--- a/interpreter/templates/v2/report_skeleton.md
+++ b/interpreter/templates/v2/report_skeleton.md
@@ -1,20 +1,25 @@
-# Report skeleton (aim for four pages)
+# Report skeleton
 
-1. Headline — one sentence.
-2. What to watch this month — five to eight entries, ranked by the blended
-   attention ordering, each stating its reason code in plain words: country
-   and hazard, what the forecast says in words, why it stands out, what the
-   model was reacting to, likely impacts, operational difficulty, lead time.
-3. Biggest expected impacts — nominal and per-capita views side by side (the
-   per-capita ranking already applies an absolute floor).
-4. Where the system disagreed with itself — questions the Horizon Scanner
-   flagged as regime change where the ensemble came back at the base rate,
-   and the reverse. The most interesting section; nobody else produces it.
-5. What changed since last month — entries, exits, largest movements, and how
+1. Headline. One sentence: the single thing a reader should take away.
+2. The scan this month. How wide it was and what came out of it, in three
+   sentences at most, using the count placeholders.
+3. Potentially worsening situations: climate hazards. Drought, flood and
+   tropical cyclone sitting above what history would lead you to expect.
+4. Potentially worsening situations: conflict. The same, for armed conflict.
+5. Major impact but roughly stable: climate hazards. A heavy burden per head
+   of population, with no call that things are departing from the usual.
+6. Major impact but roughly stable: conflict. The same, for armed conflict.
+7. What changed since last month. Entries, exits, largest movements, and how
    last month's flagged risks are tracking.
-6. How well did we do — scores in plain English, the skill statement against
-   climatology, best and worst calls on high regime-change questions, Track 1
-   versus Track 2 (skill vs own climatology only), Track 1 versus Sibyl
-   (covered set only), this run against the system average.
-7. What we cannot see — resolution gaps, unscored hazards, standing biases.
-8. Appendix — probability lexicon, run provenance, model lineup, cost.
+8. How well did we do. Scores in plain English, the skill statement against
+   climatology, best and worst calls, and the standing warning that Track 1
+   and Track 2 cover different questions and cannot be compared on raw
+   scores.
+9. What we cannot see. Resolution gaps, unscored hazards, standing biases.
+10. Appendix. The probability lexicon and run provenance.
+
+Sections 3 to 6 are not yours to choose. The pack has already placed every
+entry in one of them; copy the placement across. Each entry gives its reason
+in plain words, what the forecast says, the shape of that forecast, what the
+system was reacting to, what it would mean for people, and what would make
+responding hard.

--- a/interpreter/tests/test_selection_names_charts.py
+++ b/interpreter/tests/test_selection_names_charts.py
@@ -259,3 +259,72 @@ class TestPackRecordOrder:
 
         got = packs.pack_categories(self._pack())
         assert got == {"covered": ("worsening", "climate")}
+
+
+class TestTemplateFigureContract:
+    """A template naming a figure key nothing produces is a broken report.
+
+    This is the guard that was missing: interpreter/templates/v2/system.md
+    told the model to write {{fig:ev_multiple}}, the selection module computed
+    ev_multiple onto every attention row, and the figure map never exposed it.
+    Every worsening entry's headline number rendered [figure unavailable] and
+    the referential check failed the whole report.
+    """
+
+    def _template_keys(self) -> set[str]:
+        import re
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[1] / "templates"
+        keys: set[str] = set()
+        for path in root.rglob("*.md"):
+            keys |= set(re.findall(r"\{\{fig:([A-Za-z0-9_.-]+)\}\}", path.read_text()))
+        return keys
+
+    def test_template_figure_keys_are_all_produced(self):
+        from interpreter import packs
+
+        produced = (
+            set(packs._ATTENTION_FIG_KEYS)
+            | set(packs._RUN_SUMMARY_KEYS)
+            | set(packs._PERFORMANCE_KEYS)
+        )
+        missing = sorted(self._template_keys() - produced)
+        assert not missing, (
+            f"templates instruct {{{{fig:...}}}} keys nothing produces: {missing}. "
+            "Add them to packs._ATTENTION_FIG_KEYS (per-question), "
+            "_RUN_SUMMARY_KEYS (run-level) or _PERFORMANCE_KEYS "
+            "(scored), or stop naming them."
+        )
+
+    def test_attention_keys_exist_on_a_real_attention_row(self):
+        """Every per-question figure key must be a column the pack carries."""
+        from scripts.ai_bundle.build_current_run_bundle import ATTENTION_FIELDS
+        from interpreter import packs
+
+        # baserate_source and the rank columns are pack columns too; anything
+        # here that ATTENTION_FIELDS does not carry can never resolve.
+        missing = sorted(set(packs._ATTENTION_FIG_KEYS) - set(ATTENTION_FIELDS))
+        assert not missing, f"figure keys absent from the attention index: {missing}"
+
+
+class TestKindIsStated:
+    def test_current_run_template_tells_the_model_its_kind(self):
+        """The model wrote kind='current' on a combined run because the v2
+        template dropped the {{KIND}} placeholder prompts.py substitutes."""
+        from pathlib import Path
+
+        text = (
+            Path(__file__).resolve().parents[1]
+            / "templates" / "v2" / "current_run.md"
+        ).read_text()
+        assert "{{KIND}}" in text
+
+    def test_assembled_prompt_names_the_kind(self):
+        from interpreter import prompts
+
+        text = prompts.build_user_prompt(
+            kind="combined", pack_text="PACK", version="v2"
+        )
+        assert "{{KIND}}" not in text
+        assert "`combined`" in text

--- a/interpreter/tests/test_validate.py
+++ b/interpreter/tests/test_validate.py
@@ -365,3 +365,51 @@ class TestCategories:
     def test_no_categorised_rows_skips_rather_than_fails(self):
         result = validate_mod.check_categories(_content(), pack_categories={})
         assert result.passed and result.skipped
+
+
+class TestFigureKeyNormalisation:
+    """The model writes figure_refs as "fig:x" because the prose syntax is
+    {{fig:x}}. The prefix carries no meaning; rejecting it failed a whole
+    report over punctuation."""
+
+    def test_prefixed_refs_resolve(self):
+        content = _content()
+        content["attention"][0]["figure_refs"] = [
+            "js_vs_baserate", "fig:js_vs_baserate", "{{fig:js_vs_baserate}}",
+        ]
+        result = validate_mod.check_referential(
+            content,
+            valid_question_ids={QID},
+            per_question={QID: {"js_vs_baserate": 0.3}},
+            global_figures={"skill_brier_spd": 0.4},
+        )
+        assert result.passed, result.errors
+
+    def test_a_genuinely_missing_key_still_fails(self):
+        content = _content()
+        content["attention"][0]["figure_refs"] = ["fig:not_a_real_key"]
+        result = validate_mod.check_referential(
+            content,
+            valid_question_ids={QID},
+            per_question={QID: {"js_vs_baserate": 0.3}},
+            global_figures={},
+        )
+        assert not result.passed
+
+
+class TestCodeCheckPrecision:
+    """FAO and IOM are prose. SOM and NIC are codes a reader cannot decode."""
+
+    def test_agency_acronyms_are_not_codes(self):
+        for text in ("The FAO reported shortages.",
+                     "IOM tracked the movement.",
+                     "WHO and ICRC both responded."):
+            assert validate_mod.find_codes_in_prose(text) == [], text
+
+    def test_real_iso3_codes_are_still_caught(self):
+        assert "SOM" in validate_mod.find_codes_in_prose("SOM is worsening.")
+        assert "NIC" in validate_mod.find_codes_in_prose("Watch NIC this month.")
+
+    def test_metric_enums_and_slash_forms_still_caught(self):
+        assert validate_mod.find_codes_in_prose("EVENT_OCCURRENCE is up.")
+        assert validate_mod.find_codes_in_prose("The DR/PA forecast.")

--- a/interpreter/validate.py
+++ b/interpreter/validate.py
@@ -194,12 +194,29 @@ def _referenced_figures(
     return out
 
 
+def _normalise_figure_key(key: str) -> str:
+    """``fig:eiv_nominal`` and ``{{fig:eiv_nominal}}`` both mean ``eiv_nominal``.
+
+    The figure maps are keyed on the bare name, but a model asked to write
+    ``{{fig:x}}`` in prose reasonably writes ``fig:x`` in figure_refs too. The
+    prefix carries no meaning, so accepting it costs nothing; rejecting it
+    failed a whole report over punctuation.
+    """
+    text = str(key or "").strip()
+    if text.startswith("{{") and text.endswith("}}"):
+        text = text[2:-2].strip()
+    if text.startswith("fig:"):
+        text = text[4:]
+    return text
+
+
 def _lookup_figure(
     key: str,
     qids: list[str],
     per_question: dict[str, dict[str, Any]],
     global_figures: dict[str, Any],
 ) -> tuple[bool, Any]:
+    key = _normalise_figure_key(key)
     for qid in qids:
         figs = per_question.get(qid)
         if figs and key in figs:
@@ -473,20 +490,32 @@ _NOT_BUT = re.compile(r"\bnot\s+(?:a|an|the)?\s*[^,.;]{1,40},\s*but\b", re.IGNOR
 # Em dash and en dash. Full stops, commas and semi-colons only.
 _DASHES = ("—", "–")
 
-# A code leaking into prose: three capitals standing alone (ISO3), or one of
-# the metric enums. Hazard codes are two letters and too easily a real word,
-# so they are checked only in their slash form ("DR/PA").
-_ISO3_IN_PROSE = re.compile(r"(?<![A-Za-z])[A-Z]{3}(?![A-Za-z])")
+# A code leaking into prose. Three capitals alone are NOT enough to condemn a
+# token: FAO, IOM, WHO and ICRC are ordinary prose to a humanitarian reader,
+# and flagging them failed a correct report. Only a token that is genuinely an
+# ISO3 country code counts, because that is the one a reader cannot decode
+# and the one the entry heading is supposed to have spelled out.
+_CAPS_IN_PROSE = re.compile(r"(?<![A-Za-z])[A-Z]{3}(?![A-Za-z])")
 _METRIC_CODES = ("EVENT_OCCURRENCE", "PHASE3PLUS_IN_NEED", "FATALITIES")
 _HAZARD_SLASH = re.compile(r"\b[A-Z]{2}/[A-Z_]{2,}")
 
-# Country names that legitimately contain a three-capital run, plus the
-# handful of acronyms a humanitarian reader expects to see spelled that way.
-_ALLOWED_CAPS = {
-    "UN", "OCHA", "IPC", "ACLED", "IFRC", "IDMC", "GDACS", "FEWS", "NET",
-    "WFP", "UNHCR", "DREF", "ENSO", "USD", "NGO", "NGOs", "IDP", "IDPs",
-    "SPD", "RC", "EM", "DAT",
-}
+# A few ISO3 codes are also words or common acronyms in humanitarian prose.
+# "CAR" is the Central African Republic's code and an English noun; "AND",
+# "ARE", "CAN", "ALL", "ONE", "TON", "USA", "GBR" read as prose or as names a
+# reader already knows. Allowing them risks missing a real code; refusing them
+# guarantees false positives on correct writing, and a validator that cries
+# wolf gets ignored.
+_ALLOWED_ISO3 = {"AND", "ARE", "CAN", "ALL", "ONE", "TON", "USA", "COD", "CAR"}
+
+
+def _iso3_codes() -> frozenset[str]:
+    """The ISO3 set, from the same country table the report names things by."""
+    try:
+        from interpreter import names as _names
+
+        return frozenset(_names.iso3_codes()) - _ALLOWED_ISO3
+    except Exception:  # noqa: BLE001 - no table means no code check, not a crash
+        return frozenset()
 
 
 def find_banned_phrases(text: str) -> list[str]:
@@ -503,10 +532,8 @@ def find_codes_in_prose(text: str) -> list[str]:
     cleaned = _strip_placeholders(text or "")
     hits = [m for m in _METRIC_CODES if m in cleaned]
     hits.extend(_HAZARD_SLASH.findall(cleaned))
-    hits.extend(
-        m for m in _ISO3_IN_PROSE.findall(cleaned)
-        if m not in _ALLOWED_CAPS
-    )
+    codes = _iso3_codes()
+    hits.extend(m for m in _CAPS_IN_PROSE.findall(cleaned) if m in codes)
     return hits
 
 


### PR DESCRIPTION
The August report generated, rendered to PDF and published — and failed validation. Everything that failed was mine. `#861` was verified against fixtures, a dry-run prompt assembly and a real pack, but never against a real model response, and these are the things only a real response could show.

## What failed

| # | Defect | Effect |
|---|---|---|
| 1 | `ev_multiple` was never in the figure map | Every worsening entry's headline number rendered `[figure unavailable]` |
| 2 | `figure_refs` arrived as `fig:ev_multiple` | 38 spurious referential errors |
| 3 | The model set `kind: "current"` on a combined run | Schema check failed |
| 4 | Style check condemned `FAO`, `IOM`, `Phase III` | 6 false positives on correct prose |
| 5 | The v2 report skeleton still described v1's sections | Contradictory instructions (unused, but a trap) |

**1** is the substantive one. `templates/v2/system.md` tells the model to write `{{fig:ev_multiple}}`, `interpreter/selection.py` computes it onto every attention row, and `packs._ATTENTION_FIG_KEYS` never exposed the key. Three places had to agree and one didn't.

**2** — the maps are keyed on the bare name, but a model taught to write `{{fig:x}}` in prose reasonably writes `fig:x` in `figure_refs`. The prefix carries no meaning, so it is normalised rather than rejected. Failing a report over punctuation is not a validation win.

**3** — `prompts.py` has always substituted `{{KIND}}` into the current-run template. My v2 rewrite dropped the placeholder, so nothing told the model which report it was writing.

**4** — a three-capital run is not a country code. The check now matches the real ISO3 set from `resolver/data/countries.csv`, which is precisely what a reader cannot decode. A short allowlist covers codes that are also English words (`CAR`, `AND`, `CAN`, …) — missing an occasional real code is a smaller cost than a validator that cries wolf and gets ignored.

## The guard

Defect 1 is the class worth preventing, so `TestTemplateFigureContract` now scans every template for `{{fig:...}}` keys and fails when one has no declared producer. It caught two more on its first run (`skill_brier_spd`, `skill_brier_binary`) and forced all three key lists to be declared constants rather than loops written inline in two places.

## What held up

Verified against the real run, not fixtures:

- **categories: passed, 21 of 21.** The pack selected 21 entries and the model placed every one under the heading the pack chose. The section logic works end to end against a real model.
- **numeric: passed.** 13 figures re-derived with independent SQL, all matched.
- **prose: passed.** No bare numerals, no lexicon-band disagreement.
- The PDF rendered 15 pages with the map and the charts.

## Tests

159 Python + 39 vitest + `tsc --noEmit` + UI guardrails, green locally. New cases pin the prefix normalisation, the narrowed code check (including "Phase III"), the `{{KIND}}` substitution, and the template figure-key contract.

After merge I'll re-run the interpreter for the August run and re-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeBr1mTG2euJsF6aG3GAeG

---
_Generated by [Claude Code](https://claude.ai/code/session_01QeBr1mTG2euJsF6aG3GAeG)_