### PR TITLE
Three defects visible in the published August report

### DIFF
--- a/interpreter/packs.py
+++ b/interpreter/packs.py
@@ -142,6 +142,27 @@ def pack_question_ids(pack: Pack) -> set[str]:
     return out
 
 
+def pack_identity(pack: Pack) -> dict[str, dict[str, str]]:
+    """{question_id: {iso3, hazard_code, metric}} straight from the pack.
+
+    These are facts about a question, not judgements, so the model's copy of
+    them is repaired rather than trusted: a mis-copied hazard_code printed
+    "Mali, fatalities: deaths" in a published report.
+    """
+    out: dict[str, dict[str, str]] = {}
+    for row in pack.attention_rows:
+        qid = str(row.get("question_id") or "")
+        if not qid:
+            continue
+        fields = {
+            name: str(row.get(name) or "")
+            for name in ("iso3", "hazard_code", "metric")
+        }
+        if all(fields.values()):
+            out[qid] = fields
+    return out
+
+
 def pack_categories(pack: Pack) -> dict[str, tuple[str | None, str | None]]:
     """{question_id: (category, hazard_family)} for the rows the pack put in a
     section. The validator holds the report to exactly this list."""

--- a/interpreter/render.py
+++ b/interpreter/render.py
@@ -88,17 +88,22 @@ def format_figure(key: str, value: Any) -> str:
             word = "close to its usual pattern"
         return word
     if key in ("log_ev_ratio", "ev_multiple"):
-        # A multiple a reader can check against the sentence around it.
-        # "1/87.5x" meant nothing; "a fraction of the usual level" does.
+        # A multiple a reader can check against the sentence around it;
+        # "1/87.5x" meant nothing. Rendered as a NOUN PHRASE, not a clause,
+        # because the model writes it inside a sentence of its own ("about
+        # {{fig:ev_multiple}} the usual number of people affected"). Returning
+        # "about 14.1 times the usual level" there produced "about about 14.1
+        # times the usual level the usual number of people affected" in a
+        # published report.
         ratio = math.exp(v) if key == "log_ev_ratio" else v
         if ratio >= 1.0:
-            return f"about {ratio:.1f} times the usual level"
+            return f"{ratio:.1f} times"
         if ratio <= 0:
-            return "far below the usual level"
+            return "a tiny fraction of"
         inverse = 1.0 / ratio
         if inverse >= 10:
-            return "a small fraction of the usual level"
-        return f"about one {_ordinal_word(inverse)} of the usual level"
+            return "a small fraction of"
+        return f"one {_ordinal_word(inverse)} of"
     if key.startswith("eiv") or key.startswith("n_") or abs(v) >= 1000:
         return f"{v:,.0f}"
     if key.startswith("mean_brier") or key.startswith("climatology_brier"):

--- a/interpreter/run.py
+++ b/interpreter/run.py
@@ -212,6 +212,36 @@ def _open_db(db: str):
     return duckdb_io, duckdb_io.get_db(db or duckdb_io.DEFAULT_DB_URL)
 
 
+def _repair_entry_identity(
+    content: dict[str, Any], identity: dict[str, dict[str, str]]
+) -> int:
+    """Overwrite each attention entry's iso3/hazard_code/metric from the pack.
+
+    Returns the number of fields corrected, logged so a persistently sloppy
+    model is visible rather than silently patched.
+    """
+    if not isinstance(content, dict) or not identity:
+        return 0
+    fixed = 0
+    for entry in content.get("attention") or []:
+        if not isinstance(entry, dict):
+            continue
+        for qid in entry.get("question_ids") or []:
+            truth = identity.get(str(qid))
+            if not truth:
+                continue
+            for name, value in truth.items():
+                if str(entry.get(name) or "") != value:
+                    LOGGER.info(
+                        "[interpreter] %s: %s %r corrected to %r from the pack",
+                        qid, name, entry.get(name), value,
+                    )
+                    entry[name] = value
+                    fixed += 1
+            break
+    return fixed
+
+
 def _maybe_inherit_test_mode(con, hs_run_id: str | None) -> None:
     """Derive test mode from the interpreted run (the Sibyl pattern).
 
@@ -409,6 +439,14 @@ def run_interpreter(
             result.update({"status": "failed_generation", "version": version,
                            "interpretation_id": interpretation_id})
             return result
+
+        # The pack owns each question's country, hazard and metric. Copying
+        # them is a transcription step with no judgement in it, so a slip is
+        # repaired here rather than published or made fatal: the August run
+        # copied FATALITIES into hazard_code and the report printed "Mali,
+        # fatalities: deaths". The judgement fields (category, hazard_family)
+        # are NOT repaired — those the validator holds the model to.
+        _repair_entry_identity(content, packs.pack_identity(pack))
 
         # --- Validation (schema, referential, numeric, prose, style, sections) ---
         report = validate.validate_interpretation(

--- a/interpreter/tests/test_render_store.py
+++ b/interpreter/tests/test_render_store.py
@@ -28,12 +28,14 @@ class TestFormatFigure:
         # Plain words, not "% of maximum" (which meant nothing to a reader).
         assert format_figure("js_vs_baserate", 0.3466) == "a long way from its usual pattern"
         assert format_figure("js_vs_baserate", 0.02) == "close to its usual pattern"
-        # A multiple a reader can check, never "1/87.5x".
+        # A multiple a reader can check, never "1/87.5x". A NOUN PHRASE, so
+        # it composes inside the model's own sentence ("about {x} the usual
+        # number of people affected"); a clause published a duplication.
         import math as _m
-        assert format_figure("log_ev_ratio", _m.log(14.11)).startswith("about 14.1 times")
-        assert format_figure("log_ev_ratio", _m.log(0.5)) == "about one half of the usual level"
-        assert format_figure("log_ev_ratio", _m.log(1 / 87.5)) == "a small fraction of the usual level"
-        assert format_figure("log_ev_ratio", 0.693) == "about 2.0 times the usual level"
+        assert format_figure("log_ev_ratio", _m.log(14.11)) == "14.1 times"
+        assert format_figure("log_ev_ratio", _m.log(0.5)) == "one half of"
+        assert format_figure("log_ev_ratio", _m.log(1 / 87.5)) == "a small fraction of"
+        assert format_figure("log_ev_ratio", 0.693) == "2.0 times"
         assert format_figure("baserate_source", "acled:6m") == "acled:6m"
         assert format_figure("anything", None) == UNAVAILABLE
 

--- a/interpreter/tests/test_selection_names_charts.py
+++ b/interpreter/tests/test_selection_names_charts.py
@@ -328,3 +328,75 @@ class TestKindIsStated:
         )
         assert "{{KIND}}" not in text
         assert "`combined`" in text
+
+
+class TestIdentityRepair:
+    """The pack owns a question's country, hazard and metric.
+
+    The August report printed "Mali, fatalities: deaths" because the model
+    copied FATALITIES into hazard_code. Copying is transcription, not
+    judgement, so it is repaired rather than published.
+    """
+
+    def test_miscopied_hazard_code_is_corrected(self):
+        from interpreter.run import _repair_entry_identity
+
+        content = {"attention": [{
+            "question_ids": ["MLI_ACE_FATALITIES_2026-09"],
+            "iso3": "MLI", "hazard_code": "FATALITIES", "metric": "FATALITIES",
+            "category": "worsening", "hazard_family": "conflict",
+        }]}
+        identity = {"MLI_ACE_FATALITIES_2026-09": {
+            "iso3": "MLI", "hazard_code": "ACE", "metric": "FATALITIES",
+        }}
+        assert _repair_entry_identity(content, identity) == 1
+        assert content["attention"][0]["hazard_code"] == "ACE"
+
+    def test_judgement_fields_are_never_touched(self):
+        from interpreter.run import _repair_entry_identity
+
+        content = {"attention": [{
+            "question_ids": ["MLI_ACE_FATALITIES_2026-09"],
+            "iso3": "MLI", "hazard_code": "ACE", "metric": "FATALITIES",
+            "category": "worsening", "hazard_family": "conflict",
+        }]}
+        identity = {"MLI_ACE_FATALITIES_2026-09": {
+            "iso3": "MLI", "hazard_code": "ACE", "metric": "FATALITIES",
+        }}
+        assert _repair_entry_identity(content, identity) == 0
+        # The validator, not this repair, owns category and hazard_family.
+        assert content["attention"][0]["category"] == "worsening"
+
+    def test_an_unknown_question_is_left_alone(self):
+        from interpreter.run import _repair_entry_identity
+
+        content = {"attention": [{
+            "question_ids": ["NOT_IN_PACK"], "iso3": "ZZZ",
+            "hazard_code": "XX", "metric": "PA",
+        }]}
+        assert _repair_entry_identity(content, {"other": {}}) == 0
+        assert content["attention"][0]["iso3"] == "ZZZ"
+
+
+class TestEvMultipleComposes:
+    """format_figure returns a noun phrase because the model writes the value
+    inside a sentence of its own. Returning a clause published "about about
+    14.1 times the usual level the usual number of people affected"."""
+
+    def test_it_reads_inside_the_prompt_own_example(self):
+        from interpreter.render import format_figure
+
+        sentence = (
+            "the system expects about "
+            + format_figure("ev_multiple", 14.11)
+            + " the usual number of people affected"
+        )
+        assert sentence == (
+            "the system expects about 14.1 times the usual number of people affected"
+        )
+        assert "the usual level the usual" not in sentence
+
+    def test_below_one_still_reads(self):
+        from interpreter.render import format_figure
+
+        assert format_figure("ev_multiple", 0.5) == "one half of"

--- a/interpreter/tests/test_validate.py
+++ b/interpreter/tests/test_validate.py
@@ -27,6 +27,9 @@ QID = "ETH_ACE_FATALITIES_2026-08"
 PER_QUESTION = {
     QID: {
         "js_vs_baserate": 0.3466,
+        "log_ev_ratio": 1.2,
+        # exp(1.2) — the readable form the report leads with.
+        "ev_multiple": 3.3201169227365472,
         "eiv_nominal": 200000.0,
         "rc_level": 2,
         "rc_score": 0.24,
@@ -413,3 +416,58 @@ class TestCodeCheckPrecision:
     def test_metric_enums_and_slash_forms_still_caught(self):
         assert validate_mod.find_codes_in_prose("EVENT_OCCURRENCE is up.")
         assert validate_mod.find_codes_in_prose("The DR/PA forecast.")
+
+
+class TestEvMultipleIsVerifiable:
+    """The report leads with ev_multiple, so the guard must be able to check it.
+
+    It could not: the first passing live report had the numeric check report
+    "0 checked, 9 unverifiable" — honest, and no protection at all, because
+    every figure the model cited was one the guard did not know how to derive.
+    ev_multiple is exp(log_ev_ratio) from the same row.
+    """
+
+    def test_ev_multiple_is_rederived_and_matched(self, tmp_path: Path):
+        con = duckdb.connect(str(tmp_path / "ev.duckdb"))
+        con.execute(
+            "CREATE TABLE forecast_deviation (run_id TEXT, question_id TEXT, "
+            "model_name TEXT, js_vs_baserate DOUBLE, log_ev_ratio DOUBLE, "
+            "eiv_nominal DOUBLE, eiv_per_100k DOUBLE)"
+        )
+        con.execute(
+            "INSERT INTO forecast_deviation VALUES "
+            f"('fc_1', '{QID}', 'ensemble_mean_v2', 0.3466, 1.2, 200000.0, 180.0)"
+        )
+        content = _content()
+        content["attention"][0]["figure_refs"] = ["ev_multiple"]
+        content["attention"][0]["why_it_stands_out"] = (
+            "About {{fig:ev_multiple}} the usual level."
+        )
+        result = check_numeric(
+            content, con=con, run_id="fc_1",
+            per_question=PER_QUESTION, global_figures=GLOBAL,
+        )
+        assert result.passed, result.errors
+        assert result.detail["n_checked"] >= 1, result.detail
+        con.close()
+
+    def test_a_wrong_ev_multiple_is_caught(self, tmp_path: Path):
+        con = duckdb.connect(str(tmp_path / "ev2.duckdb"))
+        con.execute(
+            "CREATE TABLE forecast_deviation (run_id TEXT, question_id TEXT, "
+            "model_name TEXT, js_vs_baserate DOUBLE, log_ev_ratio DOUBLE, "
+            "eiv_nominal DOUBLE, eiv_per_100k DOUBLE)"
+        )
+        con.execute(
+            "INSERT INTO forecast_deviation VALUES "
+            f"('fc_1', '{QID}', 'ensemble_mean_v2', 0.3466, 1.2, 200000.0, 180.0)"
+        )
+        figs = {QID: dict(PER_QUESTION[QID], ev_multiple=99.0)}
+        content = _content()
+        content["attention"][0]["figure_refs"] = ["ev_multiple"]
+        result = check_numeric(
+            content, con=con, run_id="fc_1",
+            per_question=figs, global_figures=GLOBAL,
+        )
+        assert not result.passed
+        con.close()

--- a/interpreter/validate.py
+++ b/interpreter/validate.py
@@ -280,11 +280,21 @@ def _db_deviation_values(con, run_id: str | None, qid: str) -> list[dict[str, An
         f"FROM forecast_deviation WHERE question_id = ?{run_clause}",
         params,
     ).fetchall()
-    return [
-        {"js_vs_baserate": r[0], "log_ev_ratio": r[1],
-         "eiv_nominal": r[2], "eiv_per_100k": r[3]}
-        for r in rows
-    ]
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        row = {"js_vs_baserate": r[0], "log_ev_ratio": r[1],
+               "eiv_nominal": r[2], "eiv_per_100k": r[3]}
+        # ev_multiple is the readable form of log_ev_ratio and is what the
+        # report actually leads with, so it must be verifiable. Without it the
+        # guard reported "0 checked, 9 unverifiable" on a whole live report:
+        # honest, and no protection at all.
+        if r[1] is not None:
+            try:
+                row["ev_multiple"] = math.exp(float(r[1]))
+            except (TypeError, ValueError, OverflowError):
+                pass
+        out.append(row)
+    return out
 
 
 def _db_triage_values(con, qid: str) -> list[dict[str, Any]]:
@@ -305,7 +315,8 @@ def _db_triage_values(con, qid: str) -> list[dict[str, Any]]:
     ]
 
 
-_DEVIATION_KEYS = ("js_vs_baserate", "log_ev_ratio", "eiv_nominal", "eiv_per_100k")
+_DEVIATION_KEYS = ("js_vs_baserate", "log_ev_ratio", "ev_multiple",
+                   "eiv_nominal", "eiv_per_100k")
 _TRIAGE_KEYS = ("rc_level", "rc_score", "triage_score")
 
 


### PR DESCRIPTION
The August report now validates clean on all six checks. Reading it turned up three things no check could see.

## 1. The multiple printed twice

The published report says:

> Across the six months to February the system expects **about about 14.1 times the usual level the usual number** of people affected by tropical cyclone.

`format_figure` returned a full clause (`"about 14.1 times the usual level"`) where the system prompt's own example uses the value as a noun phrase (`"about {{fig:ev_multiple}} the usual number of people affected"`). The renderer and the prompt disagreed about grammar, and the prompt was right. It now returns `"14.1 times"`, `"one half of"`, `"a small fraction of"`.

## 2. "Mali, fatalities: deaths"

The model copied `FATALITIES` into `hazard_code` for one entry; the pack says `ACE`. A question's country, hazard and metric are facts the pack owns and the model only transcribes, so a slip is now repaired from the pack before rendering rather than published.

`category` and `hazard_family` are deliberately **not** repaired. Those are the model's copy of a *judgement*, and the categories check exists precisely to hold it to them. Repairing a judgement would hide exactly what that check is for.

## 3. The numeric guard verified nothing

The passing report's numeric check reported `n_checked: 0, n_unverifiable_keys: 9`. It says so honestly, which is why I caught it, but honest zero coverage is still zero coverage: every figure the report cited was one the guard did not know how to re-derive, because it now leads with `ev_multiple`.

`ev_multiple` is `exp(log_ev_ratio)` from the same `forecast_deviation` row. Added to the derivable set, with a test that a doctored value is caught.

## Scale

For context on the previous run's coverage: it checked 13 figures because the report was citing `js_vs_baserate` and `eiv_nominal`. The v2→v3 change in which figures the report leads with silently moved the guard from 13/13 to 0/9. Worth remembering when a template changes which figures the prose uses.

## Tests

166 Python + 39 vitest + `tsc --noEmit` + UI guardrails, green. New cases pin the noun-phrase composition (asserting the exact sentence the prompt example produces), the identity repair including that judgement fields are untouched, and `ev_multiple` re-derivation both matching and catching a doctored value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeBr1mTG2euJsF6aG3GAeG

---
_Generated by [Claude Code](https://claude.ai/code/session_01QeBr1mTG2euJsF6aG3GAeG)_