### PR TITLE
Make the no-digits rule salient where the new fields are defined

### DIFF
--- a/interpreter/templates/v2/current_run.md
+++ b/interpreter/templates/v2/current_run.md
@@ -50,13 +50,27 @@ For each entry write:
 - `spd_shape` — one or two sentences on where the probability sits and how
   much weight is in the tail. Is the system fairly sure of a moderate
   number, or is it holding a small chance of something much larger?
+  **Write no digits here.** Do not name the size bands by their numbers.
+  Say "the middle band", "the top band", "the band above it"; the chart
+  printed beside your words carries the figures.
 - `what_the_model_was_reacting_to` — the evidence, briefly. Name the source
-  where the pack names it.
+  where the pack names it. **Write no digits here either**, however
+  tempting. A figure you read in a source document is still a number you
+  typed, and this report's standing promise is that it contains none. Say
+  "a government figure in the hundreds of thousands", "a sharp rise in
+  recorded events", "roughly a fifth of the population".
 - `impacts` — what this would mean for people, in one or two short items.
 - `operational_challenges` — access, funding, season, in one or two short
   items. Leave it out if the pack says nothing useful.
 
 Keep the whole entry under one hundred and fifty words.
+
+**One rule governs every field above: you write no digits.** Not in impacts,
+not in operational challenges, not in the reason an entry stands out. Where
+you need a figure the system computed, use its placeholder. Where you need a
+figure the system did not compute, describe its size in words. A single
+stray numeral fails the whole report, and the report says of itself that no
+number in it was written by a language model.
 
 ### `changes_since_last_run`
 

--- a/interpreter/templates/v2/system.md
+++ b/interpreter/templates/v2/system.md
@@ -10,6 +10,13 @@ such as `{{fig:ev_multiple}}`, and the renderer substitutes the value. If you
 write a digit yourself, it is wrong by construction, and the report will fail
 its checks.
 
+This holds even when the digit is not yours. A figure you read in a source
+document, a size band on a chart, a population, a count of events: if you
+type it, the report's promise that no number in it was written by a language
+model becomes false. Describe such figures in words instead. "A government
+figure in the hundreds of thousands." "The top band." "Roughly a fifth of the
+population." Only a calendar year may appear as digits.
+
 The pack has also decided which forecasts the report covers and under which
 heading. Copy the `category` and `hazard_family` across from the attention
 index. Do not promote, demote or invent an entry.


### PR DESCRIPTION
The v4 report failed the prose lint on 39 bare numerals. Grouped by field:

| count | field |
|---|---|
| 15 | `what_the_model_was_reacting_to` |
| 10 | `spd_shape` |
| 5 | `why_it_stands_out` |
| 7 | `impacts`, `operational_challenges` |

Two thirds sit in the two fields #861 introduced. `spd_shape` asks the model to describe where probability sits, so it named the size bands by their numbers. `what_the_model_was_reacting_to` asks what the evidence said, so it quoted figures out of source documents.

The rule is not new and it is not impossible to follow — **v3 obeyed it**. What was missing is that the rule lived only at the top of the system prompt while the new fields were defined pages later, each of them inviting exactly the numbers the rule forbids. Both templates now state it at the point of temptation, with the reason attached.

## What I deliberately did not do

The obvious alternative was to allow source-quoted figures in `what_the_model_was_reacting_to` — they are, after all, numbers Fred never computed and cannot supply a placeholder for. I rejected it: the report closes with *"no numbers in this report were written by the language model"*, and allowing them makes that sentence false. A reader who is told that, and then reads a figure the model typed from a document it may have misread, has been misled about the one property this report sells. Losing some specificity ("a government figure in the hundreds of thousands" for "753,024 people") is the smaller cost.

Worth flagging for you to overrule if you disagree — it is a product call, not a technical one, and it does cost the evidence section some bite.

## Also confirmed in v4

The three #863 fixes all worked against the live model:

- **Numeric coverage: 0 → 24 checked, 0 unverifiable.** The guard is doing real work again.
- The "about about … the usual level the usual number" duplication is gone.
- schema, referential, style and categories (21/21) all passed.

## Note on live state

v4 is `failed_validation`, and `/v1/interpreter/latest` serves the highest version of the newest run, so the dashboard is currently showing a report behind a warning banner. v5 from this change should restore it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeBr1mTG2euJsF6aG3GAeG

---
_Generated by [Claude Code](https://claude.ai/code/session_01QeBr1mTG2euJsF6aG3GAeG)_