### PR TITLE
One correction pass when validation fails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -614,6 +614,7 @@ Some test files require `fastapi` or `openai` which may not be installed locally
 | `PYTHIA_INTERPRETER_THINKING` | Anthropic `output_config.effort` level for the interpreter call (default high) |
 | `PYTHIA_INTERPRETER_MAX_OUTPUT_TOKENS` | Interpreter max_tokens — thinking shares this budget (default 32768) |
 | `PYTHIA_INTERPRETER_STRICT_VALIDATION` | When 1, a validation failure suppresses publication (Phase 4 consumer; default 0) |
+| `PYTHIA_INTERPRETER_VALIDATION_RETRIES` | Correction passes after a failed validation (default 1; 0 disables) |
 
 | `PYTHIA_HS_ONLY_COUNTRIES` | Restrict HS to specific countries (comma-separated ISO3s) |
 | `PYTHIA_HS_FALLBACK_MODEL_SPECS` | Fallback model for HS triage (default from profile `hs_fallback`) |

--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -225,6 +225,14 @@ failures stay inspectable):
    carries no categorised rows (a scored interpretation has no attention
    list at all).
 
+**One correction pass.** When validation fails, the runner quotes the exact
+complaints back to the model and asks for the same report with only those
+points fixed. The better of the two answers is kept, never the worse one, and
+the retry's tokens are added to the interpretation's cost. Capped at one
+(`PYTHIA_INTERPRETER_VALIDATION_RETRIES`, default 1): the failures worth
+retrying are single-sentence slips, and a model that misses twice is telling
+you something about the checks rather than about itself.
+
 A crashed check is reported as a failed check, never an unhandled error.
 `PYTHIA_INTERPRETER_STRICT_VALIDATION=1` additionally suppresses the
 publication artifacts (`--out-dir` files; the Phase 5/6 consumers honour

--- a/interpreter/config.py
+++ b/interpreter/config.py
@@ -116,6 +116,16 @@ def max_output_tokens() -> int:
     return _env_int("PYTHIA_INTERPRETER_MAX_OUTPUT_TOKENS", 32_768)
 
 
+def validation_retries() -> int:
+    """How many correction passes to allow after a failed validation.
+
+    One by default. A second call costs about the same as the first, and the
+    failures worth retrying are single-sentence slips; a model that misses
+    twice is telling us something about the checks rather than about itself.
+    """
+    return _env_int("PYTHIA_INTERPRETER_VALIDATION_RETRIES", 1)
+
+
 def strict_validation() -> bool:
     return (os.getenv("PYTHIA_INTERPRETER_STRICT_VALIDATION", "0") or "0").strip().lower() in (
         "1", "true", "yes",

--- a/interpreter/run.py
+++ b/interpreter/run.py
@@ -212,6 +212,14 @@ def _open_db(db: str):
     return duckdb_io, duckdb_io.get_db(db or duckdb_io.DEFAULT_DB_URL)
 
 
+def _error_count(report) -> list[str]:
+    """Every error string in a validation report, flattened."""
+    return [
+        err for check in report.checks.values() if not check.passed
+        for err in (check.errors or [])
+    ]
+
+
 def _repair_entry_identity(
     content: dict[str, Any], identity: dict[str, dict[str, str]]
 ) -> int:
@@ -449,16 +457,88 @@ def run_interpreter(
         _repair_entry_identity(content, packs.pack_identity(pack))
 
         # --- Validation (schema, referential, numeric, prose, style, sections) ---
-        report = validate.validate_interpretation(
-            content,
-            kind=kind,
-            valid_question_ids=packs.pack_question_ids(pack) | set(per_question),
-            per_question=per_question,
-            global_figures=global_figures,
-            con=con,
-            run_id=run_id,
-            pack_categories=packs.pack_categories(pack),
-        )
+        def _validate(candidate: dict[str, Any]):
+            return validate.validate_interpretation(
+                candidate,
+                kind=kind,
+                valid_question_ids=packs.pack_question_ids(pack) | set(per_question),
+                per_question=per_question,
+                global_figures=global_figures,
+                con=con,
+                run_id=run_id,
+                pack_categories=packs.pack_categories(pack),
+            )
+
+        report = _validate(content)
+
+        # One correction pass. Most failures that survive the prompt are a
+        # single slip in one field: a stray numeral, one banned construction.
+        # Re-running the whole cycle by hand to fix one sentence costs a full
+        # model call and leaves a banner on the dashboard in the meantime,
+        # so the runner asks for the fix itself, quoting the exact complaints.
+        # Capped at one attempt: a model that cannot satisfy the checks twice
+        # is telling us something about the checks, and the report still
+        # stores either way.
+        retries = 0
+        if not report.passed and config.validation_retries() > 0:
+            complaints = [
+                f"- {name}: {err}"
+                for name, check in report.checks.items()
+                if not check.passed
+                for err in (check.errors or [])
+            ]
+            LOGGER.warning(
+                "[interpreter] validation failed on %d point(s); asking the "
+                "model to correct them", len(complaints),
+            )
+            fix_prompt = (
+                full_prompt
+                + "\n\n## Your previous answer failed these checks\n\n"
+                + "\n".join(complaints[:60])
+                + "\n\nReturn the WHOLE report again as JSON, identical "
+                "except for the points above. Change nothing else: not the "
+                "entries covered, not their categories, not their order. "
+                "Fix only what is listed."
+            )
+            retry_text, retry_usage, retry_error = _call_model(fix_prompt, model_ref)
+            _log_llm_call(
+                model_ref=model_ref, prompt=fix_prompt, response=retry_text,
+                usage=retry_usage, error=retry_error, run_id=run_id,
+                hs_run_id=hs_run_id, kind=f"{kind}_retry",
+            )
+            retries = 1
+            retry_content = parse_model_json(retry_text) if not retry_error else None
+            if retry_content is not None:
+                _repair_entry_identity(retry_content, packs.pack_identity(pack))
+                retry_report = _validate(retry_content)
+                if retry_report.passed or len(_error_count(retry_report)) < len(complaints):
+                    # Keep the better answer, never the worse one.
+                    content, report = retry_content, retry_report
+                # The retry's tokens are part of this interpretation's cost.
+                try:
+                    from forecaster.providers import estimate_cost_usd
+
+                    extra = estimate_cost_usd(model_id, retry_usage or {})
+                    if extra:
+                        cost_usd = (cost_usd or 0.0) + extra
+                except Exception:  # noqa: BLE001
+                    pass
+                input_tokens = (input_tokens or 0) + int(
+                    (retry_usage or {}).get("prompt_tokens") or 0
+                ) or None
+                output_tokens = (output_tokens or 0) + int(
+                    (retry_usage or {}).get("completion_tokens") or 0
+                ) or None
+                common_kwargs.update(
+                    cost_usd=cost_usd, input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                )
+            else:
+                LOGGER.warning(
+                    "[interpreter] correction pass produced no usable JSON (%s); "
+                    "keeping the first answer", retry_error or "unparseable",
+                )
+
         status = "ok" if report.passed else "failed_validation"
 
         # --- Render (the report is still written on validation failure so it

--- a/interpreter/tests/test_run_end_to_end.py
+++ b/interpreter/tests/test_run_end_to_end.py
@@ -368,3 +368,75 @@ class TestTestModeDerivation:
 
         assert os.environ.get("PYTHIA_TEST_MODE") is None
         con.close()
+
+
+class TestValidationRetry:
+    """One correction pass, because the failures that survive the prompt are
+    usually a single slip in one field and a manual re-run costs a whole
+    model call plus a warning banner on the dashboard in the meantime."""
+
+    def _responses(self, monkeypatch, seq):
+        """Serve a queued list of responses; record the prompts."""
+        calls: list[str] = []
+        queue = list(seq)
+
+        def _fake(prompt: str, model_ref: str):
+            calls.append(prompt)
+            body = queue.pop(0) if queue else queue_last[0]
+            queue_last[0] = body
+            return body, {"prompt_tokens": 100, "completion_tokens": 20}, ""
+
+        queue_last = [seq[-1]]
+        monkeypatch.setattr(run_mod, "_call_model", _fake)
+        monkeypatch.setattr(run_mod, "_log_llm_call", lambda **kw: None)
+        return calls
+
+    def test_a_slip_is_corrected_and_the_report_stores_ok(
+        self, tmp_path, current_bundle, monkeypatch
+    ):
+        monkeypatch.delenv("PYTHIA_TEST_MODE", raising=False)
+        bad = _content("combined")
+        bad["attention"][0]["why_it_stands_out"] = "Roughly 40,000 people affected."
+        good = _content("combined")
+        calls = self._responses(monkeypatch, [json.dumps(bad), json.dumps(good)])
+
+        db = tmp_path / "p.duckdb"
+        result = run_interpreter(
+            db=str(db), kind="combined", pack_path=str(current_bundle)
+        )
+        assert len(calls) == 2, "the runner must ask once for a correction"
+        assert "failed these checks" in calls[1]
+        assert "bare numeral" in calls[1], "the complaint must be quoted back"
+        assert result["status"] == "ok"
+
+    def test_a_worse_correction_is_discarded(
+        self, tmp_path, current_bundle, monkeypatch
+    ):
+        monkeypatch.delenv("PYTHIA_TEST_MODE", raising=False)
+        bad = _content("combined")
+        bad["attention"][0]["why_it_stands_out"] = "Roughly 40,000 people affected."
+        worse = _content("combined")
+        worse["attention"][0]["why_it_stands_out"] = (
+            "Roughly 40,000 people affected across 12 districts."
+        )
+        self._responses(monkeypatch, [json.dumps(bad), json.dumps(worse)])
+
+        db = tmp_path / "p2.duckdb"
+        result = run_interpreter(
+            db=str(db), kind="combined", pack_path=str(current_bundle)
+        )
+        # Both fail; the runner keeps the first rather than the worse retry.
+        assert result["status"] == "failed_validation"
+
+    def test_retries_can_be_turned_off(
+        self, tmp_path, current_bundle, monkeypatch
+    ):
+        monkeypatch.delenv("PYTHIA_TEST_MODE", raising=False)
+        monkeypatch.setenv("PYTHIA_INTERPRETER_VALIDATION_RETRIES", "0")
+        bad = _content("combined")
+        bad["attention"][0]["why_it_stands_out"] = "Roughly 40,000 people affected."
+        calls = self._responses(monkeypatch, [json.dumps(bad)])
+
+        db = tmp_path / "p3.duckdb"
+        run_interpreter(db=str(db), kind="combined", pack_path=str(current_bundle))
+        assert len(calls) == 1


### PR DESCRIPTION
The v5 report failed on **one** style point:

```
style: attention[11].why_it_stands_out: banned phrase(s) ['not X, but Y']
```

Everything else was clean: schema, referential, numeric (9 checked, 0 unverifiable), prose (the #864 prompt fix worked — 39 bare numerals down to zero) and categories (21/21).

So the remaining failure mode is a model occasionally slipping on one sentence out of a four-page report. Fixing that by hand costs a full model call, a canonical DB round-trip and a publish, and leaves a warning banner on the dashboard until it lands.

## What this does

When validation fails, the runner quotes the exact complaints back to the model and asks for the same report with only those points fixed:

> Your previous answer failed these checks
> - style: attention[11].why_it_stands_out: banned phrase(s) ['not X, but Y']
>
> Return the WHOLE report again as JSON, identical except for the points above. Change nothing else: not the entries covered, not their categories, not their order. Fix only what is listed.

It keeps the **better** of the two answers, never the worse one (compared by error count), and adds the retry's tokens to the interpretation's cost so the ledger stays honest.

Capped at one pass, `PYTHIA_INTERPRETER_VALIDATION_RETRIES` (0 disables). The failures worth retrying are single-sentence slips; a model that misses twice is telling us something about the checks rather than about itself, and the report stores either way.

## Tests

Three new cases: a slip is corrected and stores `ok` (asserting the complaint is quoted back in the second prompt); a *worse* correction is discarded in favour of the first answer; and retries can be turned off. 169 Python tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeBr1mTG2euJsF6aG3GAeG

---
_Generated by [Claude Code](https://claude.ai/code/session_01QeBr1mTG2euJsF6aG3GAeG)_