### PR TITLE
Three defects the first live v3 report exposed

### DIFF
--- a/interpreter/decisions.py
+++ b/interpreter/decisions.py
@@ -98,16 +98,18 @@ def horizon_month(window_start: Any, horizon: Any) -> str | None:
 
 
 def deadline_for(peak_ym: Any, lead_months: int) -> str | None:
-    """The decision month: the peak month less the hazard's lead time.
-
-    A deadline that has already passed is still printed rather than silently
-    dropped or nudged forward. The window opens before the report does for a
-    cyclone two months out, and the honest thing to say is that the decision
-    was due already.
-    """
+    """The decision month: the peak month less the hazard's lead time."""
     if not peak_ym:
         return None
     return add_months(str(peak_ym), -int(lead_months))
+
+
+# What an already-passed deadline reads as. A drought's three-month run-up
+# subtracted from a horizon-1 peak lands two months BEFORE the report was
+# written, and the first live report duly printed "By June 2026" against three
+# of its five entries. A date in the past is not a deadline; it is a statement
+# that the run-up has already begun, and that is what the calendar should say.
+OVERDUE_LABEL = "as soon as possible"
 
 
 def decision_point(
@@ -116,12 +118,18 @@ def decision_point(
     peak_horizon: Any,
     lead_months: int,
     basis: str = DEFAULT_BASIS,
+    issued_month: Any = None,
 ) -> dict[str, Any]:
     """The derived half of an entry's decision point.
 
     The ``action`` half is the model's; everything datable is computed here.
     An empty dict means the row carries no peak horizon, which the caller
     must treat as "no derived deadline", never as a reason to invent one.
+
+    ``issued_month`` is when the report goes out. The derived month is kept
+    verbatim either way (it is the honest arithmetic and the audit trail), but
+    a deadline before the report exists is LABELLED as immediate rather than
+    printed as a month a reader cannot act on.
     """
     peak_ym = horizon_month(window_start, peak_horizon)
     if not peak_ym:
@@ -129,11 +137,17 @@ def decision_point(
     deadline = deadline_for(peak_ym, lead_months)
     if not deadline:
         return {}
+    issued = parse_ym(issued_month)
+    overdue = bool(issued and parse_ym(deadline) and parse_ym(deadline) <= issued)
     return {
         "peak_month": peak_ym,
         "peak_month_label": month_label(peak_ym),
         "deadline_month": deadline,
-        "deadline_month_label": month_label(deadline),
+        "deadline_month_label": (
+            OVERDUE_LABEL if overdue else month_label(deadline)
+        ),
+        "derived_deadline_month_label": month_label(deadline),
+        "overdue": overdue,
         "lead_time_months": int(lead_months),
         "basis": basis,
     }
@@ -172,6 +186,7 @@ def calendar_rows(
             "metric": row.get("metric_name") or row.get("metric"),
             "deadline_month": decision.get("deadline_month"),
             "deadline_label": decision.get("deadline_month_label") or "not dated",
+            "overdue": bool(decision.get("overdue")),
             "peak_label": decision.get("peak_month_label") or "",
             "basis": BASIS_LABELS.get(
                 str(decision.get("basis") or DEFAULT_BASIS), ""

--- a/interpreter/secondopinion.py
+++ b/interpreter/secondopinion.py
@@ -140,6 +140,47 @@ def _content_tokens(text: str) -> list[str]:
     ]
 
 
+# Sibyl's traces mix two kinds of prose: what it LEARNED about the world, and
+# how it went about forecasting. The first live run printed "Nudged q0.99 up
+# modestly to 150,000 to respect the fat conditional tail", "further research
+# would not materially move the distribution, so submitting" and "Fetching the
+# dedicated war article should give a month-by-month casualty timeline" under a
+# heading promising things the main system did not know. None of those is a
+# finding; two are a to-do list.
+#
+# So a sentence is dropped when it talks about the forecast rather than about
+# the situation. Matched on vocabulary that only appears in forecasting talk,
+# and on the first person, which a factual finding never needs.
+_PROCESS_MARKERS = re.compile(
+    r"""\b(
+        q0\.\d+ | quantile | quantiles | posterior | prior[s]? | draws? |
+        pooled | median | percentile | distribution | calibrat\w* |
+        submitting | submit | nudged? | seeded | anchor\w* | my\ (?:central|
+        estimate|forecast|read) | i\ (?:therefore|stay|keep|set|put|assume|
+        will|would|should|expect\ to)
+    )\b""",
+    re.IGNORECASE | re.VERBOSE,
+)
+# A research to-do rather than a statement: no finite verb, or an opening that
+# only makes sense as a question to go and answer.
+_TODO_OPENERS = re.compile(
+    r"^(any\b|whether\b|check\b|confirm\b|fetch\w*\b|search\b|verify\b|"
+    r"look\b|find\b|need\ to\b|todo\b|month-by-month\b)",
+    re.IGNORECASE,
+)
+_BARE_URL = re.compile(r"^\s*https?://\S+\s*$", re.IGNORECASE)
+
+
+def _is_process_talk(sentence: str) -> bool:
+    """Is this about the forecast rather than about the world?"""
+    text = sentence.strip()
+    if _BARE_URL.match(text):
+        return True  # a link is a citation, not a finding
+    if _TODO_OPENERS.match(text):
+        return True
+    return bool(_PROCESS_MARKERS.search(text))
+
+
 def _sentences(text: str) -> list[str]:
     out: list[str] = []
     for chunk in re.split(r"[\n\r]+", text or ""):
@@ -179,6 +220,8 @@ def novel_facts(
                 continue
             specific = bool(_PROPER.search(sentence)) or bool(_DIGIT.search(sentence))
             if not specific:
+                continue
+            if _is_process_talk(sentence):
                 continue
             if sentence.lower() in known_lower:
                 continue

--- a/interpreter/tests/test_v3_modules.py
+++ b/interpreter/tests/test_v3_modules.py
@@ -41,6 +41,28 @@ class TestDecisions:
         assert point["deadline_month"] == "2026-08"
         assert point["deadline_month_label"] == "August 2026"
 
+    def test_a_deadline_before_the_report_exists_reads_as_immediate(self):
+        # Drought's three-month run-up subtracted from a horizon-1 peak lands
+        # BEFORE the report is written. The first live report printed
+        # "By June 2026" against three of its five entries, which is not a
+        # deadline; it is a statement that the run-up has already begun.
+        point = decisions.decision_point(
+            window_start="2026-09-01", peak_horizon=1, lead_months=3,
+            issued_month="2026-08",
+        )
+        assert point["deadline_month"] == "2026-06"       # the arithmetic stands
+        assert point["derived_deadline_month_label"] == "June 2026"
+        assert point["overdue"] is True
+        assert point["deadline_month_label"] == decisions.OVERDUE_LABEL
+
+    def test_a_future_deadline_keeps_its_month(self):
+        point = decisions.decision_point(
+            window_start="2026-09-01", peak_horizon=5, lead_months=1,
+            issued_month="2026-08",
+        )
+        assert point["overdue"] is False
+        assert point["deadline_month_label"] == "December 2026"
+
     def test_no_peak_horizon_means_no_derived_deadline(self):
         # The caller must treat this as "no deadline", never as licence to
         # invent one.
@@ -115,6 +137,35 @@ class TestSecondOpinion:
             "further deterioration cannot be ruled out at this stage.",
         ]
         assert secondopinion.novel_facts(trials, known) == []
+
+    def test_sibyls_own_forecasting_talk_is_not_a_finding(self):
+        # Every one of these is verbatim from the first live report, printed
+        # under a heading promising things the main system did not know. Two
+        # of them are a research to-do list.
+        known = "Drought conditions persist across the country."
+        process = [
+            "Since Dec-Feb are always 0 and Nov is usually 0, ~2/3 of draws "
+            "should be 0, so q0.1-q0.5 = 0.",
+            "I therefore stay close to the pooled empirical quantiles, "
+            "trimming only marginally at q0.9-q0.95.",
+            "Any dated Phase 2 milestone or deadline falling within Sept "
+            "2026-Feb 2027",
+            "Fetching the dedicated war article should give a month-by-month "
+            "casualty timeline before I submit.",
+            "Nudged q0.99 up modestly to 150,000 to respect the fat "
+            "conditional tail, so submitting.",
+            "https://www.un.org/unispal/document/bulletin-april-2026-en-ar/",
+        ]
+        assert secondopinion.novel_facts(process, known, limit=10) == []
+
+    def test_a_real_finding_still_survives_the_filter(self):
+        known = "Conflict continues in several regions."
+        finding = (
+            "Indepaz recorded 48 massacres and 229 deaths between January and "
+            "April 2026, the worst since 2016."
+        )
+        out = secondopinion.novel_facts([finding], known, limit=2)
+        assert out == [finding]
 
     def test_trial_texts_walks_whatever_shape_the_traces_are_in(self):
         trials = {"trials": [{"belief_trace": [

--- a/interpreter/tests/test_validate.py
+++ b/interpreter/tests/test_validate.py
@@ -290,6 +290,26 @@ class TestProperNounGuard:
         )
         assert result.detail["violations"] == []
 
+    def test_a_possessive_country_name_is_the_same_name(self):
+        # "Afghanistan's drought" flagged on the guard's first live run and
+        # cost a correction pass to remove a country name the report is
+        # required to print. That is the false positive that gets a checker
+        # switched off.
+        content = self._content_with(
+            "Afghanistan's outlook is the reason, and Somalia's is worse."
+        )
+        result = validate_mod.check_proper_nouns(
+            content, evidence_text=self.EVIDENCE
+        )
+        assert result.detail["violations"] == []
+
+    def test_a_possessive_invented_name_is_still_flagged(self):
+        content = self._content_with("Typhoon Maysak's track shifted west.")
+        result = validate_mod.check_proper_nouns(
+            content, evidence_text=self.EVIDENCE
+        )
+        assert any("Maysak" in v for v in result.detail["violations"])
+
     def test_a_sentence_initial_capital_is_grammar_not_a_name(self):
         content = self._content_with("Rainfall drove the change.")
         result = validate_mod.check_proper_nouns(

--- a/interpreter/validate.py
+++ b/interpreter/validate.py
@@ -655,6 +655,17 @@ def _known_names() -> set[str]:
     return out
 
 
+# A possessive is the same name. "Afghanistan's drought" flagged on the first
+# live run and cost a correction pass to remove a country name the report is
+# required to print, which is precisely the false positive that gets a checker
+# switched off.
+_POSSESSIVE = re.compile(r"['’]s?$")
+
+
+def _bare(word: str) -> str:
+    return _POSSESSIVE.sub("", word)
+
+
 def find_unsupported_proper_nouns(text: str, evidence_lower: str) -> list[str]:
     """Proper nouns in one prose field that the pack's evidence does not carry."""
     cleaned = _strip_placeholders(text or "")
@@ -671,10 +682,13 @@ def find_unsupported_proper_nouns(text: str, evidence_lower: str) -> list[str]:
             phrase = match.group(0).strip()
             if len(phrase) < 4:
                 continue
-            words = [w for w in phrase.replace("-", " ").split() if w[:1].isupper()]
+            words = [
+                _bare(w) for w in phrase.replace("-", " ").split()
+                if w[:1].isupper()
+            ]
             if all(w in allowed for w in words):
                 continue
-            if phrase.lower() in evidence_lower:
+            if _bare(phrase).lower() in evidence_lower:
                 continue
             # A multiword name whose distinctive half is present is supported:
             # "Typhoon Yagi" is fine when the pack says "Yagi".

--- a/scripts/ai_bundle/build_current_run_bundle.py
+++ b/scripts/ai_bundle/build_current_run_bundle.py
@@ -391,6 +391,11 @@ def build_attention_rows(
     # The window each row's horizons are counted from, kept for the decision
     # calendar (below) and dropped before the CSV is written.
     starts = {str(q["question_id"]): q.get("window_start_date") for q in questions}
+    # When the report goes out, so a derived deadline that has already passed
+    # is labelled immediate rather than printed as a month a reader cannot act
+    # on. The forecasts are issued in the month before the window opens.
+    earliest = min((str(v)[:7] for v in starts.values() if v), default="")
+    issued_month = _decisions.add_months(earliest, -1) if earliest else None
 
     _rank(rows, "js_vs_baserate", "rank_deviation")
     _rank(rows, "eiv_nominal", "rank_impact_nominal")
@@ -432,6 +437,7 @@ def build_attention_rows(
             window_start=starts.get(str(row["question_id"])),
             peak_horizon=row.get("peak_horizon"),
             lead_months=_interp_config.lead_time_months(row.get("hazard_code")),
+            issued_month=issued_month,
         )
         row["decision"] = decision or None
         row["decision_deadline"] = (decision or {}).get("deadline_month")


### PR DESCRIPTION
Follow-up to #867, from reading the report it actually produced ([backfill run](https://github.com/kwyjad/Pythia/actions/runs/31425721689), report v7, now on the release).

**The ordering fix held.** Indonesia's cyclone question dropped to the watchlist, and the report says so by name under "flagged last month and not shown this month": *"Indonesia, tropical cyclone: it no longer passes the selection tests."* These are the three things it got wrong.

### 1. Deadlines in the past

Drought's three-month run-up subtracted from a horizon-1 peak lands *before* the report is written, so three of five calendar rows read **"By June 2026"** on a report issued 1 August 2026.

I had reasoned in the code comment that printing a passed deadline was the honest thing. In practice it makes the row useless, and the model noticed before I did — it wrote *"Donors and cluster leads to decide **now**"* in the action beside a June deadline.

The arithmetic still stands in the data (`deadline_month`, `derived_deadline_month_label`); the printed label now reads **"as soon as possible"** when the run-up has already begun, with an `overdue` flag on the row.

### 2. Sibyl's own forecasting talk printed as findings

Under a heading promising things the main system did not know, the report published:

> Nudged q0.99 up modestly to 150,000 to respect the fat conditional tail; further research would not materially move the distribution, so submitting.

> Fetching the dedicated war article should give a month-by-month casualty timeline and the late-July status before I submit.

The novelty score was working exactly as designed: those sentences are specific, they contain numbers, and their vocabulary is absent from an SPD prompt. They are simply not about the world — one is a research to-do list.

Sentences carrying forecasting vocabulary (quantiles, draws, priors, "nudged", "submitting"), the first person, a bare URL, or a to-do opener are now dropped. Checked against all ten real traces from the live run: the three genuine findings survive (Indepaz massacre counts, UNMISS civilian killings, West Bank land seizure) and all seven process sentences go.

### 3. A possessive country name flagged as an invented one

`"Afghanistan's"` tripped the proper-noun guard on its first live run and cost a full correction pass to remove a country name the report is *required* to print. That is precisely the false positive that gets a checker switched off. A trailing possessive is now stripped before lookup; `"Typhoon Maysak's"` is still caught.

### Not fixed here — a calibration finding for you to rule on

The gate table from the live run:

```
run                   seen  unusual  material  worsening  burden  watch  thin     cut
fc_1785557077          185       37        78          1      77     28   138   0.114
```

**Only one question cleared all three keys**, and it is the one now leading the report — Ethiopia, armed conflict, on an expected excess of **+5 deaths**, which the model itself describes as *"roughly 1.0 times the usual monthly toll"*.

The cause is that the materiality key tests the **absolute level**, as the brief specifies: P(≥100 deaths) is ~1.0 for Ethiopia because Ethiopia always exceeds 100 deaths. So a chronically large caseload passes "material" trivially, and any positive excess then reads as "worsening". It is the Indonesia failure inverted — Indonesia was a huge multiple of almost nothing; this is almost nothing on top of a huge baseline.

The minimal fix would be to require the **excess itself** to be material rather than the level. That changes the gate you specified, so I have not made it unilaterally. Say the word and it is a small change. Two related numbers worth your eye: 138 of 185 anchors (75%) are marked thin at the 12-observation cutoff, and the body of the report runs 11 pages against the brief's target of 7 (the appendix's 185-row question table takes it to 25 overall, which is expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwVujDzuf4zcL8zbVNvrN8)_