### PR TITLE
Two leaks the second live report still showed

### DIFF
--- a/interpreter/render.py
+++ b/interpreter/render.py
@@ -508,7 +508,8 @@ def _decision_calendar_lines(
         "", "## The decision calendar", "",
         "What has to be decided, for where, and by when. Each deadline is the "
         "month with most expected impact, less the run-up that hazard needs. "
-        "A deadline already past is printed as it falls.",
+        "Where that run-up has already begun, the row says so instead of "
+        "naming a month that has passed.",
         "",
         "| By | Country | Hazard | Decision |",
         "| --- | --- | --- | --- |",

--- a/interpreter/secondopinion.py
+++ b/interpreter/secondopinion.py
@@ -178,6 +178,13 @@ def _is_process_talk(sentence: str) -> bool:
         return True  # a link is a citation, not a finding
     if _TODO_OPENERS.match(text):
         return True
+    # A finding is a statement. Sibyl's traces carry its open questions in the
+    # same field as its answers ("Is the July ACLED figure of 79 real or an
+    # artifact of coding lag?"), and the second run printed three of them under
+    # a heading promising things the main system did not know. A question mark
+    # is the one unambiguous marker of a question, wherever it falls.
+    if "?" in text:
+        return True
     return bool(_PROCESS_MARKERS.search(text))
 
 

--- a/interpreter/tests/test_v3_modules.py
+++ b/interpreter/tests/test_v3_modules.py
@@ -155,6 +155,12 @@ class TestSecondOpinion:
             "Nudged q0.99 up modestly to 150,000 to respect the fat "
             "conditional tail, so submitting.",
             "https://www.un.org/unispal/document/bulletin-april-2026-en-ar/",
+            # Verbatim from the SECOND live run: Sibyl keeps its open
+            # questions in the same field as its answers, and a question is
+            # not a finding however specific it is.
+            "Is the July 2026 ACLED figure of 79 real or an artifact of "
+            "coding lag / genuine lull?",
+            "August 2026 strike tempo - is 18/month holding or creeping up?",
         ]
         assert secondopinion.novel_facts(process, known, limit=10) == []
 


### PR DESCRIPTION
Follow-up to #868, from reading report **v8** ([now on the release](https://github.com/kwyjad/Pythia/releases/tag/pythia-data-latest)).

Both fixes from #868 landed and work. The calendar now reads **"as soon as possible"** where it read "By June 2026", and the process talk is gone from the second reader's section — no more *"Nudged q0.99 up modestly… so submitting"*, no bare URLs, no *"Fetching the dedicated war article…"*. Two things still leaked.

### 1. Sibyl's open questions printed as findings

Three survived the process-talk filter:

> Is the July 2026 ACLED figure of 79 real or an artifact of coding lag / genuine lull?

> August 2026 strike tempo — is 18/month holding or creeping up?

> Is ACLED's July figure of 9 a reporting-lag artifact or genuine?

They pass every test the filter applies: specific, numeric, and their vocabulary genuinely is absent from an SPD prompt. They are simply questions. Sibyl keeps its open questions in the same trace field as its answers.

A finding is a statement, so any sentence containing a question mark is now dropped. That is blunt on purpose — it is the one unambiguous marker of a question, wherever it falls.

### 2. The calendar described a rule it no longer follows

The intro still read *"A deadline already past is printed as it falls"*, which stopped being true the moment #868 changed the label. A report that describes its own rules wrongly is worse than one that says nothing, because the reader has no way to check. It now says the row reports an already-open run-up instead of naming a month that has passed.

### What v8 looks like otherwise

Good, and unchanged in the ways that matter: 24 pages, status `ok`, all seven checks passing, Indonesia still on the watchlist and named in "flagged last month and not shown this month", the genuine novel findings still surfacing (Indepaz massacre counts, UNMISS civilian killings, West Bank land seizure, typhoon remnants driving inland flooding in Gansu).

**The gate calibration question from #868 is still open and still yours to rule on** — it is unaffected by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwVujDzuf4zcL8zbVNvrN8)_