### PR TITLE
Two ways the report page lied about what it was showing

### DIFF
--- a/pythia/api/routes/interpreter.py
+++ b/pythia/api/routes/interpreter.py
@@ -234,7 +234,7 @@ def interpreter_attention_map(
     """
     con = _con()
     if not _table_exists(con, "forecast_deviation") or not _table_exists(con, "questions"):
-        return {"has_data": False, "run_id": None, "rows": []}
+        return {"has_data": False, "has_movement": False, "run_id": None, "rows": []}
 
     if not run_id:
         rows = _execute(
@@ -248,7 +248,8 @@ def interpreter_attention_map(
         ).fetchall()
         run_id = rows[0][0] if rows and rows[0] and rows[0][0] else None
     if not run_id:
-        return {"has_data": False, "run_id": None, "rows": []}
+        return {"has_data": False, "has_movement": False, "run_id": None,
+                "rows": []}
 
     pref_cases = " ".join(
         f"WHEN model_name = '{m}' THEN {i}" for i, m in enumerate(_MODEL_PREFERENCE)
@@ -328,7 +329,20 @@ def interpreter_attention_map(
         r["movement"] = (
             max(-3.0, min(float(move), 3.0)) if move is not None else None
         )
-    return {"has_data": bool(rows), "run_id": run_id, "rows": rows}
+    # Whether the map can be DRAWN, reported separately from whether there are
+    # rows at all. A database predating the movement migration, or one whose
+    # deviation rows have not been recomputed, yields rows with movement=None
+    # for every country — which renders as a uniformly grey world under a
+    # legend promising colours. That is a soft-fail wearing the empty state's
+    # clothes, and the dashboard is not allowed to do that, so the frontend is
+    # told which case it is in and says so.
+    return {
+        "has_data": bool(rows),
+        "has_movement": any(r.get("movement") is not None for r in rows),
+        "movement_columns_present": has_movement,
+        "run_id": run_id,
+        "rows": rows,
+    }
 
 
 # The dynamic path is declared LAST so the literal routes above always win.

--- a/pythia/tests/test_api_interpreter.py
+++ b/pythia/tests/test_api_interpreter.py
@@ -198,7 +198,7 @@ def test_pre_interpreter_db_has_interpretation_false(api_env) -> None:
     assert body == {"has_interpretation": False, "kind": "combined"}
     assert client.get("/v1/interpreter/versions").json() == {"rows": []}
     assert client.get("/v1/interpreter/attention_map").json() == {
-        "has_data": False, "run_id": None, "rows": [],
+        "has_data": False, "has_movement": False, "run_id": None, "rows": [],
     }
 
 
@@ -238,6 +238,28 @@ def test_attention_map_preference_scaling_and_test_filter(api_env) -> None:
     assert eth["attention"] == pytest.approx(0.60 / math.log(2.0))
     assert eth["n_questions"] == 2
     assert by_iso3["KEN"]["attention"] == pytest.approx(0.20 / math.log(2.0))
+
+
+def test_attention_map_says_when_it_cannot_be_drawn(api_env) -> None:
+    """A DB predating the movement migration must SAY so, not go grey.
+
+    This is the live symptom: the dashboard served a uniformly grey world
+    under a legend promising colours, because every row's movement was null
+    and the frontend had no way to tell that apart from "no countries moved".
+    The fixture DB has no delta_p50/delta_p90/movement_threshold columns,
+    which is exactly the state a canonical DB is in before compute_deviation
+    has run with them.
+    """
+    client = api_env()
+    body = client.get("/v1/interpreter/attention_map").json()
+    # There ARE rows — the map is not empty, it is undrawable.
+    assert body["has_data"] is True
+    assert body["rows"]
+    assert body["has_movement"] is False
+    assert body["movement_columns_present"] is False
+    assert all(r["movement"] is None for r in body["rows"])
+    # The undirected value is still served, so a caller can explain itself.
+    assert all(r["attention"] is not None for r in body["rows"])
 
 
 def test_attention_map_include_test(api_env) -> None:

--- a/web/src/app/interpreter/InterpreterClient.tsx
+++ b/web/src/app/interpreter/InterpreterClient.tsx
@@ -27,6 +27,8 @@ import {
   movementLegend,
   countryAnchorId,
   groupVersionsByRun,
+  newestServedVersion,
+  pdfVersionFromAsset,
   statusBanner,
 } from "./lib";
 
@@ -35,12 +37,14 @@ export default function InterpreterClient({
   versions,
   attentionMap,
   reportPdfUrl = null,
+  reportPdfAsset = null,
   reportPublishedButMissing = false,
 }: {
   report: InterpreterReport | null;
   versions: InterpreterVersionRow[];
   attentionMap: InterpreterAttentionMapResponse;
   reportPdfUrl?: string | null;
+  reportPdfAsset?: string | null;
   reportPublishedButMissing?: boolean;
 }) {
   const router = useRouter();
@@ -57,6 +61,28 @@ export default function InterpreterClient({
     });
     return out;
   }, [attentionMap.rows]);
+
+  // The map is drawn from the SIGNED movement and from nothing else. When the
+  // database behind this API predates those columns every value is null, and
+  // drawing the map anyway produced a uniformly grey world under a legend
+  // promising colours — a soft-fail wearing the empty state's clothes. Say so
+  // instead, and say which of the two causes it is.
+  const mapUnavailable = useMemo(() => {
+    if (!attentionMap.has_data) return null;
+    if (Object.keys(valuesByIso3).length > 0) return null;
+    if (attentionMap.movement_columns_present === false) {
+      return (
+        "This database was built before the movement figures existed, so " +
+        "there is nothing to shade yet. The map returns with the next " +
+        "forecast cycle; the report below is unaffected."
+      );
+    }
+    return (
+      "No country in this run has a movement figure yet — the deviation " +
+      "table has the columns but has not been recomputed for it. The map " +
+      "returns once it is; the report below is unaffected."
+    );
+  }, [attentionMap.has_data, attentionMap.movement_columns_present, valuesByIso3]);
 
   const reportIso3 = useMemo(() => {
     const set = new Set<string>();
@@ -114,8 +140,26 @@ export default function InterpreterClient({
 
   const banner = report ? statusBanner(report.status) : null;
 
+  // The published PDF carries its version in its filename. When that is newer
+  // than anything the API served, the reader is looking at an older report
+  // than the one the Download button hands them, and only the page can see
+  // both numbers at once.
+  const pdfVersion = pdfVersionFromAsset(reportPdfAsset);
+  const servedVersion = newestServedVersion(versions);
+  const pdfIsNewerThanScreen =
+    pdfVersion != null && servedVersion != null && pdfVersion > servedVersion;
+
   return (
     <div className="space-y-6">
+      {pdfIsNewerThanScreen ? (
+        <div className="rounded-md border border-amber-400 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          The published PDF is version {pdfVersion}, but the newest report this
+          API can serve is version {servedVersion} — its database is still
+          catching up with the release. Download the PDF for the current
+          report; the on-page version should follow within a few minutes.
+        </div>
+      ) : null}
+
       {attentionMap.has_data ? (
         <section className="space-y-2">
           <div className="flex items-center gap-2">
@@ -132,18 +176,24 @@ export default function InterpreterClient({
               }
             />
           </div>
-          <RiskIndexMap
-            riskRows={[]}
-            countriesRows={[]}
-            view="PA_EIV"
-            valuesByIso3={valuesByIso3}
-            colorFor={movementColor}
-            valueLabelFor={movementLabel}
-            legendItems={legendItems}
-            onCountryClick={handleCountryClick}
-            showRcOverlay={false}
-            heightClassName="h-[420px]"
-          />
+          {mapUnavailable ? (
+            <div className="rounded-md border border-amber-400 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+              {mapUnavailable}
+            </div>
+          ) : (
+            <RiskIndexMap
+              riskRows={[]}
+              countriesRows={[]}
+              view="PA_EIV"
+              valuesByIso3={valuesByIso3}
+              colorFor={movementColor}
+              valueLabelFor={movementLabel}
+              legendItems={legendItems}
+              onCountryClick={handleCountryClick}
+              showRcOverlay={false}
+              heightClassName="h-[420px]"
+            />
+          )}
         </section>
       ) : null}
 

--- a/web/src/app/interpreter/__tests__/lib.test.ts
+++ b/web/src/app/interpreter/__tests__/lib.test.ts
@@ -22,6 +22,8 @@ import {
   groupAttention,
   monthLabel,
   groupVersionsByRun,
+  newestServedVersion,
+  pdfVersionFromAsset,
   runMonthLabel,
   sectionHeading,
   statusBanner,
@@ -312,5 +314,51 @@ describe("decision deadlines", () => {
     expect(monthLabel(undefined)).toBe("no dated deadline");
     expect(monthLabel("")).toBe("no dated deadline");
     expect(monthLabel("2026-13")).toBe("no dated deadline");
+  });
+});
+
+describe("the published PDF against the report on screen", () => {
+  // The release and the API's database catch up at different speeds. On
+  // 2026-08-11 the Download button offered v10 while the page's newest
+  // selectable report was v9, and nothing on the page said so: the reader
+  // could only tell by opening the PDF. The existing "still syncing" banner
+  // did not cover it, because it fires only when the API has NO report.
+  it("reads the version out of a published asset name", () => {
+    expect(pdfVersionFromAsset("report__2026-08__v10.pdf")).toBe(10);
+    expect(pdfVersionFromAsset("report__2026-08__v9.pdf")).toBe(9);
+  });
+
+  it("returns nothing rather than guessing", () => {
+    // The constant-name asset carries no version, and a missing manifest key
+    // must not be read as version zero — either would make the comparison
+    // fire on every page load.
+    expect(pdfVersionFromAsset("interpreter_report_latest.pdf")).toBeNull();
+    expect(pdfVersionFromAsset(null)).toBeNull();
+    expect(pdfVersionFromAsset(undefined)).toBeNull();
+    expect(pdfVersionFromAsset("")).toBeNull();
+  });
+
+  it("takes the newest version served across every run", () => {
+    const rows = [
+      { version: 9 },
+      { version: 2 },
+      { version: 7 },
+    ];
+    expect(newestServedVersion(rows)).toBe(9);
+  });
+
+  it("says nothing when the API served no report at all", () => {
+    expect(newestServedVersion([])).toBeNull();
+    expect(newestServedVersion([{ version: null }])).toBeNull();
+  });
+
+  it("catches the live mismatch and stays quiet when they agree", () => {
+    const served = newestServedVersion([{ version: 9 }]);
+    expect(pdfVersionFromAsset("report__2026-08__v10.pdf")! > served!).toBe(
+      true
+    );
+    expect(pdfVersionFromAsset("report__2026-08__v9.pdf")! > served!).toBe(
+      false
+    );
   });
 });

--- a/web/src/app/interpreter/lib.ts
+++ b/web/src/app/interpreter/lib.ts
@@ -252,3 +252,25 @@ export const statusBanner = (
   }
   return { tone: "warn", text: `Unexpected report status: ${status}` };
 };
+
+// The version number inside a published PDF's filename, e.g.
+// "report__2026-08__v10.pdf" -> 10. The release and the API's database are
+// two different stores that catch up at different speeds, and the page has
+// no other way to tell that the Download PDF button is offering something
+// newer than anything it can show on screen.
+export const pdfVersionFromAsset = (asset?: string | null): number | null => {
+  const match = /__v(\d+)\.pdf$/i.exec(String(asset ?? ""));
+  if (!match) return null;
+  const n = Number(match[1]);
+  return Number.isFinite(n) ? n : null;
+};
+
+// The newest version the API actually served, across every run.
+export const newestServedVersion = (
+  rows: Array<{ version?: number | null }>
+): number | null => {
+  const versions = (rows ?? [])
+    .map((r) => (typeof r.version === "number" ? r.version : null))
+    .filter((v): v is number => v != null);
+  return versions.length ? Math.max(...versions) : null;
+};

--- a/web/src/app/interpreter/page.tsx
+++ b/web/src/app/interpreter/page.tsx
@@ -31,6 +31,7 @@ export default async function InterpreterPage({
   let versions: InterpreterVersionsResponse = { rows: [] };
   let attentionMap: InterpreterAttentionMapResponse = {
     has_data: false,
+    has_movement: false,
     run_id: null,
     rows: [],
   };
@@ -79,6 +80,14 @@ export default async function InterpreterPage({
     versionResult.status === "fulfilled"
       ? versionResult.value.interpreter_report_url ?? null
       : null;
+  // The versioned filename (report__2026-08__v10.pdf) is the only way the page
+  // can tell that the Download PDF button is offering a NEWER report than
+  // anything the API can serve — the release and the API's database are two
+  // stores that catch up at different speeds.
+  const reportPdfAsset =
+    versionResult.status === "fulfilled"
+      ? versionResult.value.interpreter_report_versioned_asset ?? null
+      : null;
   // The release advertising a report PDF while the API serves no report means
   // the API's DB is behind the release it just read the manifest from — a
   // soft-fail, which must never be dressed as "no data".
@@ -107,6 +116,7 @@ export default async function InterpreterPage({
         versions={versions.rows}
         attentionMap={attentionMap}
         reportPdfUrl={reportPdfUrl}
+        reportPdfAsset={reportPdfAsset}
         reportPublishedButMissing={reportPublishedButMissing}
       />
     </div>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -9,6 +9,10 @@ export type VersionResponse = {
   // these into manifest.json, and /v1/version passes manifest keys through.
   interpreter_report_url?: string | null;
   interpreter_report_asset?: string | null;
+  // e.g. "report__2026-08__v10.pdf" — the version the RELEASE carries. The
+  // page compares it against the newest version the API can serve, because
+  // a v10 download button beside a v9 report tells the reader nothing.
+  interpreter_report_versioned_asset?: string | null;
 };
 
 export type DiagnosticsSummaryResponse = {
@@ -665,6 +669,12 @@ export type InterpreterAttentionMapRow = {
 
 export type InterpreterAttentionMapResponse = {
   has_data: boolean;
+  // Whether the map can be DRAWN, reported separately from whether rows
+  // exist. A database that predates the movement columns, or whose deviation
+  // rows have not been recomputed, has rows whose movement is null for every
+  // country — a grey world under a legend promising colours.
+  has_movement?: boolean;
+  movement_columns_present?: boolean;
   run_id: string | null;
   rows: InterpreterAttentionMapRow[];
 };


### PR DESCRIPTION
Two defects reported from the live dashboard after the v4 publish. Both have the same shape: the page was showing a stale or undrawable view as if it were a current one.

## The map was entirely grey

The v4 choropleth is drawn from the SIGNED movement (`delta_p50` / `delta_p90` / `movement_threshold` on `forecast_deviation`) and from nothing else. Against a database that predates those columns every value is null, and `RiskIndexMap` dutifully drew a uniformly grey world underneath a legend promising warm and cool shading. Nothing on the page distinguished that from "no country moved this month".

Falling back to the old undirected attention scale was the tempting fix and is the wrong one — that scale shaded a country whose forecast had FALLEN exactly like one whose forecast had risen, which is the defect v4 replaced it to fix. So instead:

- `/v1/interpreter/attention_map` now returns `has_movement` (did any row get a figure?) and `movement_columns_present` (does the table even have the columns?) alongside its rows.
- The page prints which of the two cases it is in — a database built before the migration, or one whose deviation rows have not been recomputed for this run — rather than rendering a grey map.

The undirected `attention` value is still served on each row, so a caller can explain itself; it is simply no longer what the map is coloured by.

## The Download PDF button offered v10 while the screen showed v9

The release asset and the API's DuckDB are two stores that sync at different speeds by design. The existing "still syncing" banner did not cover this because it fires only when the API has **no** report at all, not when it has an **older** one — so the only way to discover the mismatch was to open the PDF.

The release asset carries its version in its filename (`report__2026-08__v10.pdf`), so the page can now compare it against the newest version the API served and say plainly that the database is catching up.

## Changes

- `pythia/api/routes/interpreter.py` — `has_movement` / `movement_columns_present` on the attention-map response.
- `web/src/app/interpreter/lib.ts` — `pdfVersionFromAsset`, `newestServedVersion` (pure, unit-tested).
- `web/src/app/interpreter/InterpreterClient.tsx` — the map note and the version-mismatch banner.
- `web/src/app/interpreter/page.tsx` — threads `interpreter_report_versioned_asset` through from `/v1/version`.
- `web/src/lib/types.ts` — the three new optional fields.

## Tests

- `pythia/tests/test_api_interpreter.py::test_attention_map_says_when_it_cannot_be_drawn` pins the exact live symptom: rows exist, every `movement` is null, `has_movement` and `movement_columns_present` are both false. 9 passed.
- `web/src/app/interpreter/__tests__/lib.test.ts` — five cases over the two new helpers, including that a versionless `interpreter_report_latest.pdf` and a missing manifest key both return null rather than zero (either would fire the banner on every page load). 34 passed; full web suite 49 passed, `tsc --noEmit` clean.

Both files already run in a workflow (`interpreter-ci.yml` names the API test; `web-ci.yml` runs the vitest suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFiQZ3aajdCEgfqjBxcU2Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFiQZ3aajdCEgfqjBxcU2Z)_